### PR TITLE
Create the otpBase64FileInput directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "angular-2-dropdown-multiselect": "^1.5.4",
     "angular2-jsonapi": "^3.6.0",
     "angular2-spinner": "^1.0.10",
+    "angular2-web-worker": "^0.0.6",
     "core-js": "^2.4.1",
     "date-fns": "^1.28.5",
     "express": "^4.15.2",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,6 +30,8 @@ import { CountryDetailComponent } from 'app/pages/fields/countries/country-detai
 import { SpeciesListComponent } from 'app/pages/fields/species/species-list.component';
 import { SpeciesService } from 'app/services/species.service';
 import { ObserverListComponent } from 'app/pages/fields/observers/observer-list.component';
+import { WebWorkerService } from 'app/services/webworker.service';
+import { Base64FileInputDirective } from 'app/directives/base64-file-input.directive';
 import { ActionBarComponent } from 'app/shared/action-bar/action-bar.component';
 import { SpeciesDetailComponent } from 'app/pages/fields/species/species-detail.component';
 import { ObserverDetailComponent } from 'app/pages/fields/observers/observer-detail.component';
@@ -122,6 +124,7 @@ import { MultiselectDropdownModule } from 'angular-2-dropdown-multiselect';
     FiltersComponent,
     FilterDirective,
     ModalComponent,
+    Base64FileInputDirective
   ],
   imports: [
     JsonApiModule,
@@ -149,6 +152,7 @@ import { MultiselectDropdownModule } from 'angular-2-dropdown-multiselect';
     SpeciesService,
     CategoriesService,
     ResponsiveService,
+    WebWorkerService,
     { provide: RequestOptions, useClass: OauthRequestOptions }
   ],
   bootstrap: [AppComponent]

--- a/src/app/directives/base64-file-input.directive.ts
+++ b/src/app/directives/base64-file-input.directive.ts
@@ -1,0 +1,184 @@
+import { Directive, ElementRef, Input, HostListener, OnChanges, SimpleChanges, forwardRef, Output, EventEmitter } from '@angular/core';
+import { Validator, AbstractControl, ValidationErrors, NG_VALIDATORS, NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+import { WebWorkerService } from 'app/services/webworker.service';
+
+const MAX_SIZE_VALIDATOR: any = {
+  provide: NG_VALIDATORS,
+  useExisting: forwardRef(() => Base64FileInputDirective),
+  multi: true
+};
+
+const VALUE_ACCESSOR: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => Base64FileInputDirective),
+  multi: true
+};
+
+@Directive({
+  selector: '[otpBase64FileInput][ngModel]',
+  providers: [MAX_SIZE_VALIDATOR, VALUE_ACCESSOR]
+})
+export class Base64FileInputDirective implements Validator, OnChanges, ControlValueAccessor {
+
+  // Max size of the file, by default 2MB
+  @Input() maxSize = 1024 * 1024 * 2;
+  // State of the input
+  @Output() loading = new EventEmitter<boolean>();
+
+  private validatorCallback: () => void;
+  private modelCallback: (_: string) => void;
+  private touchCallback: (_: string) => void;
+  private file: File;
+  private base64: string;
+  private conversionError: boolean;
+
+  constructor(el: ElementRef, private webWorkerService: WebWorkerService) {
+    el.nativeElement.style.color = 'red';
+  }
+
+  /**
+   * Event handler executed when the attributes of the input change
+   * @param {SimpleChanges} changes attributes
+   */
+  ngOnChanges(changes: SimpleChanges): void {
+    for (const key in changes) {
+      if (key === 'maxSize') {
+        this.maxSize = +changes[key].currentValue;
+        this.propagateChange();
+      }
+    }
+  }
+
+  @HostListener('change', ['$event.target'])
+  async onChange(input: HTMLInputElement) {
+    this.file = input.files[0];
+    this.conversionError = false;
+
+    // We trigger the validation each time the file is changed
+    this.propagateChange();
+
+    // If the file weights too much, we exit the event handler
+    if (!this.isSizeValid(this.file)) {
+      return;
+    }
+
+    this.loading.emit(true);
+
+    const worker = this.webWorkerService
+      .run(this.workerFunction, this.file)
+      .then(res => {
+        this.base64 = res;
+      })
+      .catch(e => {
+        this.conversionError = true;
+      })
+      .then(() => {
+        this.propagateChange();
+        this.loading.emit(false);
+
+        // We terminate the service worker
+        this.webWorkerService.terminate(worker);
+      });
+
+  }
+
+  /**
+   * Return the list of errors
+   * @param {AbstractControl} c
+   * @returns {ValidationErrors}
+   */
+  validate(c: AbstractControl): ValidationErrors {
+    if (!this.file) {
+      return null;
+    }
+
+    return {
+      maxSize: !this.isSizeValid(this.file)
+    };
+  }
+
+  /**
+   * Return whether the size of the file is valid
+   * @param {File} file file to check
+   * @returns {boolean}
+   */
+  isSizeValid(file: File): boolean {
+    return file.size <= this.maxSize;
+  }
+
+  /**
+   * This method pass us the function to call when we modify the
+   * value of the input from the inside
+   * The function will trigger the validation
+   * @param {() => void} fn
+   */
+  registerOnValidatorChange(fn: () => void): void {
+    this.validatorCallback = fn;
+  }
+
+  /**
+   * Method executed by the outside world when the input recieves a value
+   * @param {*} obj
+   */
+  writeValue(obj: any): void {
+    if (!obj) {
+      return;
+    }
+
+    // NOTE: obj must be a base64 string here
+    this.base64 = obj;
+  }
+
+  /**
+   * This method pass us the function to call when we modify the
+   * value of the input from the inside
+   * The function will update ngModel
+   * @param {() => void} fn
+   */
+  registerOnChange(fn: any): void {
+    this.modelCallback = fn;
+  }
+
+  /**
+   * This method pass us the function to call when we modify the
+   * value of the input from the inside
+   * The function will update ngModel
+   * @param {() => void} fn
+   */
+  registerOnTouched(fn: any): void {
+    this.touchCallback = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {}
+
+  /**
+   * Propage the change to the validator and the model
+   */
+  propagateChange(): void {
+    if (this.validatorCallback) {
+      this.validatorCallback();
+    }
+
+    if (this.modelCallback) {
+      this.modelCallback(this.base64);
+    }
+
+    if (this.touchCallback) {
+      this.touchCallback(this.base64);
+    }
+  }
+
+  /**
+   * Convert the file to base64
+   */
+  workerFunction(postMessage: (_: string) => void, file: File): void {
+    const fileReader = new FileReader();
+
+    fileReader.addEventListener('load', ({ target}: Event) => {
+      postMessage((<string>(<FileReader>target).result));
+    });
+
+    fileReader.readAsDataURL(file);
+  }
+
+}

--- a/src/app/models/observer.model.ts
+++ b/src/app/models/observer.model.ts
@@ -11,7 +11,7 @@ export class Observer extends JsonApiModel {
   @Attribute() observer_type?: ['Mandated', 'SemiMandated', 'External', 'Government'];
   @Attribute() organization?: string;
   @Attribute() is_active?: boolean;
-  @Attribute() logo?: any;
+  @Attribute() logo?: string;
 
   @BelongsTo() country: Country;
   @BelongsTo() users: User[];

--- a/src/app/services/webworker.service.ts
+++ b/src/app/services/webworker.service.ts
@@ -1,0 +1,31 @@
+import { IWebWorkerService } from 'angular2-web-worker';
+import { WebWorkerService as service } from 'angular2-web-worker';
+
+export class WebWorkerService extends service implements IWebWorkerService {
+
+  run<T>(workerFunction: (postMessage: (message: T) => void, any) => void, data?: any): Promise<T> {
+    return super.run(workerFunction, data);
+  }
+
+  runUrl(url: string, data?: any): Promise<any> {
+    return super.runUrl(url, data);
+  }
+
+  terminate<T>(promise: Promise<T>): Promise<T> {
+    return super.terminate(promise);
+  }
+
+  // We override the method to enable postMessage to be called whenever we want
+  // This allows us to asynchronously trigger postMessage
+  private createWorkerUrl(resolve: Function): string {
+    const resolveString = resolve.toString();
+    // The change is here: postMessage is passed as argument
+    const webWorkerTemplate = `
+        self.addEventListener('message', function(e) {
+            (${resolveString})(postMessage, e.data);
+        });
+    `;
+    const blob = new Blob([webWorkerTemplate], { type: 'text/javascript' });
+    return URL.createObjectURL(blob);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,6 +303,10 @@ angular2-spinner@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/angular2-spinner/-/angular2-spinner-1.0.10.tgz#88ecc2d25320db2fba2f1231b7361bafa8ae63d1"
 
+angular2-web-worker@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/angular2-web-worker/-/angular2-web-worker-0.0.6.tgz#5915326e81ea6d781ec1e6c4d4a35f59d0a55642"
+
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"


### PR DESCRIPTION
This PR contains the basics to manage base64-uploadable files.

It creates a directive, `otpBase64FileInput`, to attach to file inputs that automatically convert the files to base64 strings in a web worker. Additionally, it supports validation for the file size.

### Usage

```html
<label for="logo">Logo</label>
<input type="file" name="logo" id="logo" ngModel #logo="ngModel" otpBase64FileInput maxSize="6291456" accept="image/*" (loading)="onLoading($event)" />

<div *ngIf="logo.errors?.maxSize" class="help-text">The file should weight less than 6MB</div>
<div *ngIf="f.submitted && !logo.valid" class="help-text">The logo is not valid</div>
```

In this example:
* we added the attribute `otpBase64FileInput` so the input gets the desired behaviour
* we added an optional  `maxSize` attribute to validate the size of the file; the value is in bytes (by default 2MB)
* we use the standard `accept` attribute to restrict the type of file the user can submit
* we added a `onLoading` listener to display a loader if necessary

The base64 string can be get through `logo.value`. **Note that the value will be null if the file isn't valid.**

This PR doesn't contain any UI element as it should be treated separately. I suggest we create a new component to manage the upload of a document and an image. The `loading` directive will be used to let the user know the file is being processed.

Because the processing of the image can take up to several seconds, the conversion is made in a web worker (separate thread). That's why the loader is so important. **Also note that until the processing is done, the base64 value is unavailable. The submit button of the form should then be disabled or the file won't be submitted if the user clicks early.**

The web worker is managed by a new service `WebWorkerService` which is based on the library [angular2-web-worker](https://github.com/haochi/angular2-web-worker). Unfortunately, the library doesn't support asynchronous tasks in the worker so the service contained in `app` overrides the service of the library. I've created [an issue](https://github.com/haochi/angular2-web-worker/issues/9) on the library's repository to allow asynchronous work.
