### PR TITLE
Update the user permissions

### DIFF
--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -29,12 +29,17 @@ export class LoginComponent implements OnInit {
   login() {
     this.loading = true;
     this.authService.login(this.model.username, this.model.password)
-      .then(() => this.router.navigate([this.returnUrl]))
+      .then(isLogged => {
+        if (!isLogged) {
+          alert('You are not allowed to access this app');
+        } else {
+          this.router.navigate([this.returnUrl]);
+        }
+      })
       .catch((error) => {
         alert('You entered a wrong username+password combination');
-        console.log(error);
-        this.loading = false;
-     });
+      })
+      .then(() => this.loading = false);
   }
 
   triggerRegister() {

--- a/src/app/pages/observations/observation-list.component.html
+++ b/src/app/pages/observations/observation-list.component.html
@@ -34,9 +34,11 @@
     <ngx-datatable-column prop="details" name="Observation"></ngx-datatable-column>
     <ngx-datatable-column prop="severity.level" name="Severity"></ngx-datatable-column>
     <ngx-datatable-column name="Actions">
-     <ng-template let-row="row" ngx-datatable-cell-template>
-       <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
-       <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>
+      <ng-template let-row="row" ngx-datatable-cell-template>
+        <ng-template [ngIf]="canEdit(row)">
+          <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
+          <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>
+        </ng-template>
      </ng-template>
     </ngx-datatable-column>
   </ngx-datatable>

--- a/src/app/pages/observations/observation-list.component.ts
+++ b/src/app/pages/observations/observation-list.component.ts
@@ -1,3 +1,4 @@
+import { AuthService } from 'app/services/auth.service';
 import { NavigationItem } from 'app/shared/navigation/navigation.component';
 import { Router } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
@@ -27,7 +28,8 @@ export class ObservationListComponent implements OnInit {
 
   constructor(
     private router: Router,
-    private observationsService: ObservationsService
+    private observationsService: ObservationsService,
+    private authService: AuthService
   ) {}
 
   ngOnInit(): void {
@@ -44,6 +46,7 @@ export class ObservationListComponent implements OnInit {
   onEdit(row): void {
     this.router.navigate([`/private/observations/edit/${row.id}`]);
   }
+
   onDelete(row): void {
     if(confirm(`Are you sure to delete the observation with details: ${row.details}?`)) {
       this.observationsService.deleteObservationWithId(row.id).then(
@@ -52,6 +55,17 @@ export class ObservationListComponent implements OnInit {
           this.ngOnInit();
         });
     }
+  }
+
+  /**
+   * Return whether the logged user can edit or delete an observation
+   * @param {Observation} observation
+   * @returns {boolean}
+   */
+  canEdit(observation: Observation): boolean {
+    return observation.user
+      ? observation.user.id === this.authService.userId
+      : this.authService.userRole === 'admin';
   }
 
   getCategory(row): string {

--- a/src/app/pages/register/register.component.html
+++ b/src/app/pages/register/register.component.html
@@ -8,15 +8,6 @@
   <div class="row">
     <div class="large-10 columns">
       <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
-        <div class="form-group">
-            <label for="permissions_request">Are you an operator or NGO?
-              <select name="permissions_request" ngModel #permissions_request="ngModel">
-                 <option default selected value="default"> Please select if you are an operator or an NGO</option>
-                 <option value="ngo">NGO</option>
-                 <option value="operator">Operator</option>
-              </select>
-            </label>
-        </div>
         <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !name.valid }">
             <label for="name">Name</label>
             <input id="name" type="text" class="form-control" name="name" ngModel #name="ngModel" required />

--- a/src/app/pages/register/register.component.ts
+++ b/src/app/pages/register/register.component.ts
@@ -36,6 +36,9 @@ export class RegisterComponent implements OnInit {
       delete payload.user.permissions_request;
     }
 
+    // We only create NGO users
+    payload.user.permissions_request = 'ngo';
+
     this.http.post(`${environment.apiUrl}/register`, payload)
       .map(response => response.json())
       .toPromise().then(

--- a/src/app/pages/users/user-detail.component.html
+++ b/src/app/pages/users/user-detail.component.html
@@ -60,10 +60,8 @@
         <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !user_permission_attributes.valid }">
           <label for="user_permission_attributes">Permissions</label>
           <select id="user_permission_attributes" name="user_permission_attributes" [(ngModel)]="user && user.user_permission.user_role" #user_permission_attributes="ngModel">
-            <option value="admin" disabled>Admin</option>
+            <option value="admin">Admin</option>
             <option value="ngo">NGO</option>
-            <option value="operator">Operator</option>
-            <option value="user">User</option>
           </select>
         </div>
 

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -9,8 +9,8 @@ import 'rxjs/add/operator/toPromise';
 @Injectable()
 export class AuthService {
 
-  private userId: string;
-  private userRole: string;
+  public userId: string;
+  public userRole: string;
 
   constructor(
     private http: Http,

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -9,62 +9,78 @@ import 'rxjs/add/operator/toPromise';
 @Injectable()
 export class AuthService {
 
-    userId: string = null;
-    admin = false;
-    token: string = null;
+  private userId: string;
+  private userRole: string;
 
-    constructor(
-      private http: Http,
-      private tokenService: TokenService,
-      private router: Router
-    ) {}
+  constructor(
+    private http: Http,
+    private tokenService: TokenService,
+    private router: Router
+  ) {}
 
-    login(email: string, password: string) {
-      return this.http.post(`${environment.apiUrl}/login`, {
-          auth: {
-            email,
-            password
-          }
-        })
-        .map(response => response.json())
-        .map(body => {
-            this.token = body.token;
-            this.tokenService.token = body.token;
-            return true;
-        }).toPromise();
+  /**
+   * Log the user
+   * Reject if the login/password combination is wrong, resolve false if the user
+   * is not permitted to log in, resolve true if everything's fine
+   * @param {string} email user email
+   * @param {string} password user password
+   * @returns {Promise<boolean>}
+   */
+  login(email: string, password: string): Promise<boolean> {
+    const payload = { auth: { email, password } };
+
+    return this.http.post(`${environment.apiUrl}/login`, payload)
+      .map(response => response.json())
+      .map(body => {
+        if (body.role !== 'ngo' && body.role !== 'admin') {
+          return false;
+        }
+
+        this.tokenService.token = body.token;
+        this.userId = body.user_id;
+        this.userRole = body.role;
+
+        return true;
+      }).toPromise();
+  }
+
+  /**
+   * Check if the user is logged correctly
+   * Reject if the user isn't logged, resolve otherwise
+   * @returns {Promise<boolean>}
+   */
+  checkLogged(): Promise<boolean> {
+    if (!this.tokenService.token) {
+      return new Promise((resolve, reject) => reject());
     }
 
-    checkLogged(): Promise<boolean> {
-      return this.http.get(`${environment.apiUrl}/users/current-user`)
-        .map(response => response.json())
-        .map(response => {
-          this.userId = response.data.id;
-          this.admin = response.included.length && response.included[0].attributes.user_role === 'admin';
-          return true;
-        }).toPromise();
+    return this.http.get(`${environment.apiUrl}/users/current-user`)
+      .map(response => true)
+      .toPromise();
+  }
 
-    }
+  /**
+   * Return whether the current user is an admin
+   * @returns {boolean}
+   */
+  isAdmin(): Promise<boolean> {
+    return new Promise(resolve => {
+      resolve(this.userRole === 'admin');
+    });
+  }
 
-    /**
-     * Return whether the current user is an admin
-     * @returns {boolean}
-     */
-    isAdmin(): Promise<boolean> {
-      return new Promise(resolve => resolve(this.admin));
-    }
+  logout() {
+      this.tokenService.token = null;
+      this.userId = null;
+      this.userRole = null;
+      this.router.navigate(['/']);
+  }
 
-    logout() {
-        this.userId = null;
-        this.token = null;
-        this.tokenService.token = null;
-        this.router.navigate(['/']);
-    }
-
-    recoverPass(email: string): Promise<boolean> {
-        return new Promise((resolve, reject) => reject(false));
-        // To be updated and reviewed
-        // return this.http.post(`${environment.apiUrl}/api/v1/user/${email}/recover-password`, {})
-        // .map(response => response.json()).toPromise()
-        // .then((body:any) => this.tokenService.token = body.access_token);
-    }
+  recoverPass(email: string): Promise<boolean> {
+      return new Promise((resolve, reject) => reject(false));
+      // To be updated and reviewed
+      // return this.http.post(`${environment.apiUrl}/api/v1/user/${email}/recover-password`, {})
+      // .map(response => response.json()).toPromise()
+      // .then((body:any) => this.tokenService.token = body.access_token);
+  }
 }

--- a/src/app/shared/bottom-bar/bottom-bar.component.html
+++ b/src/app/shared/bottom-bar/bottom-bar.component.html
@@ -1,4 +1,4 @@
 <a role="menuitem" routerLink="observations" routerLinkActive="-active">Observations</a>
-<a role="menuitem" *ngIf="isAdmin" routerLink="fields" routerLinkActive="-active">Fields</a>
+<a role="menuitem" routerLink="fields" routerLinkActive="-active">Fields</a>
 <a role="menuitem" *ngIf="isAdmin" routerLink="users" routerLinkActive="-active">Users</a>
 <!--<a role="menuitem" routerLink="profile" routerLinkActive="-active">Profile</a>-->

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -23,8 +23,8 @@ export class HeaderComponent implements OnInit {
     ];
 
     if (!isAdmin) {
-      // We just keep the "Observations" tab
-      this.navigationItems = [this.navigationItems[0]];
+      // We just keep the "Observations" and "Observation fields" tabs
+      this.navigationItems = this.navigationItems.slice(0, 2);
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,7 +1251,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@*, debug@2, debug@2.6.4, debug@^2.1.3, debug@^2.2.0, debug@^2.6.3:
+debug@*, debug@2, debug@2.6.4, debug@^2.2.0, debug@^2.6.3:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.4.tgz#7586a9b3c39741c0282ae33445c4e8ac74734fe0"
   dependencies:
@@ -1269,7 +1269,7 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.1:
+debug@2.6.1, debug@^2.1.3:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:


### PR DESCRIPTION
This PR updates the user permissions.

When a user register, they no longer have the option to choose between "operator" and "ngo" as the user is always created as a NGO one.

On the creation/edition form, the options "user" and "operator" have been removed. The "admin" option has been re-enabled so, in the future, admins will be able to create other admins (the API is not ready).

The NGO users can now access the observation fields page. The API might not be ready for this at this moment. I'll check it with Tiago.

Only users with role "admin" and "ngo" can log in into the app. Other roles will see and error message.

Only the author of an observation or the admin can edit or delete it. The API might not be checking it on its side yet.