### PR TITLE
Feature/perf improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "foundation-sites": "^6.3.1",
     "leaflet": "^1.0.3",
     "ng2-datepicker": "^1.8.3",
-    "ng2-validation": "^4.1.0",
     "rxjs": "^5.1.0",
     "zone.js": "^0.8.4"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "prod-build": "ng build --prod --aot --extract-css"
+    "prod-build": "ng build --prod --aot --extract-css",
+    "bundle-report": "webpack-bundle-analyzer dist/stats.json"
   },
   "private": true,
   "dependencies": {
@@ -30,7 +31,6 @@
     "foundation-sites": "^6.3.1",
     "leaflet": "^1.0.3",
     "ng2-datepicker": "^1.8.3",
-    "ng2-responsive": "^0.8.3",
     "ng2-validation": "^4.1.0",
     "rxjs": "^5.1.0",
     "zone.js": "^0.8.4"
@@ -52,6 +52,7 @@
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0",
-    "typescript": "~2.2.0"
+    "typescript": "~2.2.0",
+    "webpack-bundle-analyzer": "^2.8.1"
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,11 @@
 <div class="pre-header">
   <div class="l-wrapper">
-    <a href="http://www.wri.org/" rel="noopener" *xs><img src="assets/wri-monoline-mbl.svg" alt="World Resources Institute" /></a>
-    <a href="http://www.wri.org/" rel="noopener" *showItSizes="{min: 768}"><img src="assets/wri-monoline.svg" alt="World Resources Institute" /></a>
+    <a href="http://www.wri.org/" rel="noopener" *otpMaxTablet><img src="assets/wri-monoline-mbl.svg" alt="World Resources Institute" /></a>
+    <a href="http://www.wri.org/" rel="noopener" *otpMinTablet><img src="assets/wri-monoline.svg" alt="World Resources Institute" /></a>
   </div>
 </div>
 <otp-header></otp-header>
 <router-outlet></router-outlet>
 <ng-template [ngIf]="isLogged">
-  <otp-bottom-bar *xs></otp-bottom-bar>
+  <otp-bottom-bar *otpMaxTablet></otp-bottom-bar>
 </ng-template>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,3 +1,6 @@
+import { EqualToValidatorDirective } from 'app/directives/equal-to.directive';
+import { EmailValidatorDirective } from 'app/directives/email.directive';
+import { NumberValidatorDirective } from 'app/directives/number.directive';
 import { ResponsiveService } from 'app/services/responsive.service';
 import { ObservationDetailEditComponent } from 'app/pages/observations/observation-detail-edit.component';
 import { AlreadyLoggedGuard } from 'app/services/already-logged.guard';
@@ -55,7 +58,6 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { JsonApiModule } from 'angular2-jsonapi';
 import { HttpModule, RequestOptions } from '@angular/http';
-import { CustomFormsModule } from 'ng2-validation';
 import { SpinnerModule } from 'angular2-spinner/dist';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 import { DatePickerModule } from 'ng2-datepicker';
@@ -103,6 +105,9 @@ import { MaxTabletDirective, MinTabletDirective } from 'app/directives/responsiv
     IconComponent,
     MaxTabletDirective,
     MinTabletDirective,
+    NumberValidatorDirective,
+    EmailValidatorDirective,
+    EqualToValidatorDirective,
   ],
   imports: [
     JsonApiModule,
@@ -110,7 +115,6 @@ import { MaxTabletDirective, MinTabletDirective } from 'app/directives/responsiv
     FormsModule,
     HttpModule,
     AppRoutingModule,
-    CustomFormsModule,
     SpinnerModule,
     NgxDatatableModule,
     DatePickerModule

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { ResponsiveService } from 'app/services/responsive.service';
 import { ObservationDetailEditComponent } from 'app/pages/observations/observation-detail-edit.component';
 import { AlreadyLoggedGuard } from 'app/services/already-logged.guard';
 import { IconComponent } from 'app/shared/icons/icon.component';
@@ -58,8 +59,8 @@ import { CustomFormsModule } from 'ng2-validation';
 import { SpinnerModule } from 'angular2-spinner/dist';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 import { DatePickerModule } from 'ng2-datepicker';
-import { ResponsiveModule } from 'ng2-responsive';
 import { ObservationsService } from 'app/services/observations.service';
+import { MaxTabletDirective, MinTabletDirective } from 'app/directives/responsive.directive';
 
 
 @NgModule({
@@ -99,7 +100,9 @@ import { ObservationsService } from 'app/services/observations.service';
     AnnexOperatorListComponent,
     AnnexGovernanceDetailComponent,
     AnnexGovernanceListComponent,
-    IconComponent
+    IconComponent,
+    MaxTabletDirective,
+    MinTabletDirective,
   ],
   imports: [
     JsonApiModule,
@@ -110,7 +113,6 @@ import { ObservationsService } from 'app/services/observations.service';
     CustomFormsModule,
     SpinnerModule,
     NgxDatatableModule,
-    ResponsiveModule,
     DatePickerModule
   ],
   providers: [
@@ -128,6 +130,7 @@ import { ObservationsService } from 'app/services/observations.service';
     SpeciesService,
     LawsService,
     CategoriesService,
+    ResponsiveService,
     { provide: RequestOptions, useClass: OauthRequestOptions }
   ],
   bootstrap: [AppComponent]

--- a/src/app/directives/email.directive.ts
+++ b/src/app/directives/email.directive.ts
@@ -1,0 +1,24 @@
+import { Directive, forwardRef } from '@angular/core';
+import { Validator, NG_VALIDATORS, AbstractControl, ValidationErrors } from '@angular/forms';
+
+@Directive({
+  // tslint:disable-next-line:directive-selector
+  selector: '[email][formControlName],[email][formControl],[email][ngModel]',
+  providers: [
+    { provide: NG_VALIDATORS, useExisting: forwardRef(() => EmailValidatorDirective), multi: true }
+  ]
+})
+export class EmailValidatorDirective implements Validator {
+
+  validate(c: AbstractControl): ValidationErrors {
+    // tslint:disable-next-line:max-line-length
+    if (/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(c.value)) {
+      return null;
+    }
+
+    return { number: true };
+  }
+
+  registerOnValidatorChange(fn: () => void): void {}
+
+}

--- a/src/app/directives/equal-to.directive.ts
+++ b/src/app/directives/equal-to.directive.ts
@@ -1,0 +1,33 @@
+import { Directive, forwardRef, Input } from '@angular/core';
+import { Validator, NG_VALIDATORS, AbstractControl, ValidationErrors, NgModel } from '@angular/forms';
+
+@Directive({
+  // tslint:disable-next-line:directive-selector
+  selector: '[equalTo][formControlName],[equalTo][formControl],[equalTo][ngModel]',
+  providers: [
+    { provide: NG_VALIDATORS, useExisting: forwardRef(() => EqualToValidatorDirective), multi: true }
+  ]
+})
+export class EqualToValidatorDirective implements Validator {
+
+  @Input() equalTo: NgModel;
+  private hasSubscribed = false;
+
+  validate(c: AbstractControl): ValidationErrors {
+    const value = c.value;
+    const otherValue = this.equalTo.value;
+
+    if (!this.hasSubscribed) {
+      this.equalTo.valueChanges.subscribe(() => c.updateValueAndValidity());
+    }
+
+    if (value === otherValue) {
+      return null;
+    }
+
+    return { equalTo: true };
+  }
+
+  registerOnValidatorChange(fn: () => void): void {}
+
+}

--- a/src/app/directives/number.directive.ts
+++ b/src/app/directives/number.directive.ts
@@ -1,0 +1,23 @@
+import { Directive, forwardRef } from '@angular/core';
+import { Validator, NG_VALIDATORS, AbstractControl, ValidationErrors } from '@angular/forms';
+
+@Directive({
+  // tslint:disable-next-line:directive-selector
+  selector: '[number][formControlName],[number][formControl],[number][ngModel]',
+  providers: [
+    { provide: NG_VALIDATORS, useExisting: forwardRef(() => NumberValidatorDirective), multi: true }
+  ]
+})
+export class NumberValidatorDirective implements Validator {
+
+  validate(c: AbstractControl): ValidationErrors {
+    if (/^-?[0-9]*(\.[0-9]+)?$/.test(c.value)) {
+      return null;
+    }
+
+    return { number: true };
+  }
+
+  registerOnValidatorChange(fn: () => void): void {}
+
+}

--- a/src/app/directives/responsive.directive.ts
+++ b/src/app/directives/responsive.directive.ts
@@ -1,0 +1,94 @@
+import { Directive, OnInit, OnDestroy, TemplateRef, ViewContainerRef, ChangeDetectorRef } from '@angular/core';
+import { ResponsiveService } from 'app/services/responsive.service';
+import { Subscription } from 'rxjs/Subscription';
+
+const TABLET_BREAKPOINT = 768;
+
+class ResponsiveDirective implements OnInit, OnDestroy {
+
+  private subscribtion: Subscription;
+  protected isVisible = true;
+  protected firstCall = true;
+
+  constructor (
+    private responsiveService: ResponsiveService,
+    private templateRef: TemplateRef<any>,
+    private viewContainerRef: ViewContainerRef,
+    private changeDetectorRef: ChangeDetectorRef
+  ) {}
+
+  ngOnInit() {
+    this.subscribtion = this.responsiveService.onResize
+      .subscribe(windowWidth => this.updateComponent(windowWidth));
+  }
+
+  ngOnDestroy() {
+    this.subscribtion.unsubscribe();
+  }
+
+  hide() {
+    this.isVisible = false;
+    this.firstCall = false;
+    this.viewContainerRef.clear();
+    this.changeDetectorRef.markForCheck();
+  }
+
+  show() {
+    this.isVisible = true;
+    this.firstCall = false;
+    this.viewContainerRef.createEmbeddedView(this.templateRef);
+    this.changeDetectorRef.markForCheck();
+  }
+
+  updateComponent(windowWidth: number) {
+  }
+
+}
+
+@Directive({
+  selector: '[otpMaxTablet]'
+})
+export class MaxTabletDirective extends ResponsiveDirective {
+
+  constructor (
+    responsiveService: ResponsiveService,
+    templateRef: TemplateRef<any>,
+    viewContainerRef: ViewContainerRef,
+    changeDetectorRef: ChangeDetectorRef
+  ) {
+    super(responsiveService, templateRef, viewContainerRef, changeDetectorRef);
+  }
+
+  updateComponent(windowWidth: number) {
+    if (windowWidth >= TABLET_BREAKPOINT && (this.isVisible || this.firstCall)) {
+      this.hide();
+    } else if (windowWidth < TABLET_BREAKPOINT && (!this.isVisible || this.firstCall)) {
+      this.show();
+    }
+  }
+
+}
+
+@Directive({
+  selector: '[otpMinTablet]'
+})
+export class MinTabletDirective extends ResponsiveDirective {
+
+  constructor (
+    responsiveService: ResponsiveService,
+    templateRef: TemplateRef<any>,
+    viewContainerRef: ViewContainerRef,
+    changeDetectorRef: ChangeDetectorRef
+  ) {
+    super(responsiveService, templateRef, viewContainerRef, changeDetectorRef);
+  }
+
+  updateComponent(windowWidth: number) {
+    if (windowWidth < TABLET_BREAKPOINT && (this.isVisible || this.firstCall)) {
+      this.hide();
+    } else if (windowWidth >= TABLET_BREAKPOINT && (!this.isVisible || this.firstCall)) {
+      this.show();
+    }
+  }
+
+}

--- a/src/app/pages/fields/categories/category-detail.component.html
+++ b/src/app/pages/fields/categories/category-detail.component.html
@@ -5,7 +5,7 @@
     <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
       <div class="c-container -j-between -t-d-column -t-a-start">
         <h2>{{titleText}}</h2>
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
@@ -17,14 +17,14 @@
         <div *ngIf="f.submitted && !name.valid" class="help-text">Name is required</div>
       </div>
 
-      <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+      <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
         <div class="c-button-container -j-end form-group">
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
       </div>
 
-      <otp-action-bar *xs>
+      <otp-action-bar *otpMaxTablet>
         <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
         <button disable="loading" type="submit" class="c-button -primary">Create</button>
       </otp-action-bar>

--- a/src/app/pages/fields/countries/country-detail.component.html
+++ b/src/app/pages/fields/countries/country-detail.component.html
@@ -4,7 +4,7 @@
     <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
       <div class="c-container -j-between -t-d-column -t-a-start">
         <h2>{{titleText}}</h2>
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
@@ -41,14 +41,14 @@
           <input id="is_active" type="checkbox" name="is_active" ngModel #is_active="ngModel" />
       </div>
 
-      <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+      <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
         <div class="c-button-container -j-end form-group">
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
       </div>
 
-      <otp-action-bar *xs>
+      <otp-action-bar *otpMaxTablet>
         <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
         <button disable="loading" type="submit" class="c-button -primary">Create</button>
       </otp-action-bar>

--- a/src/app/pages/fields/field-list.component.html
+++ b/src/app/pages/fields/field-list.component.html
@@ -1,9 +1,9 @@
-<div class="mobile-navigation" *xs>
+<div class="mobile-navigation" *otpMaxTablet>
   <otp-navigation [items]="navigationItems" layout="horizontal"></otp-navigation>
 </div>
 <div class="l-wrapper">
   <div class="c-container -j-start -a-start">
-    <otp-navigation *showItSizes="{min: 768}" [items]="navigationItems" layout="vertical"></otp-navigation>
+    <otp-navigation *otpMinTablet [items]="navigationItems" layout="vertical"></otp-navigation>
     <div class="content">
       <router-outlet ></router-outlet>
     </div>

--- a/src/app/pages/fields/governments/government-detail.component.html
+++ b/src/app/pages/fields/governments/government-detail.component.html
@@ -4,7 +4,7 @@
     <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
       <div class="c-container -j-between -t-d-column -t-a-start">
         <h2>{{titleText}}</h2>
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
@@ -27,14 +27,14 @@
         <input id="details" type="text" class="form-control" name="details" ngModel #details="ngModel" />
       </div>
 
-      <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+      <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
         <div class="c-button-container -j-end form-group">
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
       </div>
 
-      <otp-action-bar *xs>
+      <otp-action-bar *otpMaxTablet>
         <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
         <button disable="loading" type="submit" class="c-button -primary">Create</button>
       </otp-action-bar>

--- a/src/app/pages/fields/laws/law-detail.component.html
+++ b/src/app/pages/fields/laws/law-detail.component.html
@@ -4,7 +4,7 @@
     <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
       <div class="c-container -j-between -t-d-column -t-a-start">
         <h2>{{titleText}}</h2>
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
@@ -32,14 +32,14 @@
           <input id="legal_penalty" type="text" class="form-control" name="legal_penalty" ngModel #legal_penalty="ngModel" />
       </div>
 
-      <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+      <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
         <div class="c-button-container -j-end form-group">
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
       </div>
 
-      <otp-action-bar *xs>
+      <otp-action-bar *otpMaxTablet>
         <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
         <button disable="loading" type="submit" class="c-button -primary">Create</button>
       </otp-action-bar>

--- a/src/app/pages/fields/observers/observer-detail.component.html
+++ b/src/app/pages/fields/observers/observer-detail.component.html
@@ -4,7 +4,7 @@
     <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
       <div class="c-container -j-between -t-d-column -t-a-start">
         <h2>{{titleText}}</h2>
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
@@ -42,14 +42,14 @@
           <input id="active" type="checkbox" name="active" ngModel #active="ngModel" />
       </div>
 
-      <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+      <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
         <div class="c-button-container -j-end form-group">
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
       </div>
 
-      <otp-action-bar *xs>
+      <otp-action-bar *otpMaxTablet>
         <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
         <button disable="loading" type="submit" class="c-button -primary">Create</button>
       </otp-action-bar>

--- a/src/app/pages/fields/operators/operator-detail.component.html
+++ b/src/app/pages/fields/operators/operator-detail.component.html
@@ -4,7 +4,7 @@
     <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
       <div class="c-container -j-between -t-d-column -t-a-start">
         <h2>{{titleText}}</h2>
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
@@ -51,14 +51,14 @@
           <input id="active" type="checkbox" name="active" ngModel #active="ngModel" />
       </div>
 
-      <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+      <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
         <div class="c-button-container -j-end form-group">
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
       </div>
 
-      <otp-action-bar *xs>
+      <otp-action-bar *otpMaxTablet>
         <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
         <button disable="loading" type="submit" class="c-button -primary">Create</button>
       </otp-action-bar>

--- a/src/app/pages/fields/species/species-detail.component.html
+++ b/src/app/pages/fields/species/species-detail.component.html
@@ -4,7 +4,7 @@
     <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
       <div class="c-container -j-between -t-d-column -t-a-start">
         <h2>{{titleText}}</h2>
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
@@ -51,14 +51,14 @@
         TODO:  A MULTI SELECTOR OF COUNTRIES HAS TO BE ADDED HERE
         -->
 
-      <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+      <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
         <div class="c-button-container -j-end form-group">
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
       </div>
 
-      <otp-action-bar *xs>
+      <otp-action-bar *otpMaxTablet>
         <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
         <button disable="loading" type="submit" class="c-button -primary">Create</button>
       </otp-action-bar>

--- a/src/app/pages/fields/subcategories/governance/annex-governance-detail.component.html
+++ b/src/app/pages/fields/subcategories/governance/annex-governance-detail.component.html
@@ -4,7 +4,7 @@
     <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
       <div class="c-container -j-between -t-d-column -t-a-start">
         <h2>{{titleText}}</h2>
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
@@ -27,14 +27,14 @@
           <input id="details" type="text" class="form-control" name="details" ngModel #details="ngModel" />
       </div>
 
-      <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+      <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
         <div class="c-button-container -j-end form-group">
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
       </div>
 
-      <otp-action-bar *xs>
+      <otp-action-bar *otpMaxTablet>
         <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
         <button disable="loading" type="submit" class="c-button -primary">Create</button>
       </otp-action-bar>

--- a/src/app/pages/fields/subcategories/operators/annex-operator-detail.component.html
+++ b/src/app/pages/fields/subcategories/operators/annex-operator-detail.component.html
@@ -4,7 +4,7 @@
     <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
       <div class="c-container -j-between -t-d-column -t-a-start">
         <h2>{{titleText}}</h2>
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
@@ -34,14 +34,14 @@
           <input id="details" type="text" class="form-control" name="details" ngModel #details="ngModel" />
       </div>
 
-      <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+      <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
         <div class="c-button-container -j-end form-group">
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </div>
       </div>
 
-      <otp-action-bar *xs>
+      <otp-action-bar *otpMaxTablet>
         <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
         <button disable="loading" type="submit" class="c-button -primary">Create</button>
       </otp-action-bar>

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -4,13 +4,14 @@
     <form name="form" (ngSubmit)="f.form.valid && login()" #f="ngForm" novalidate>
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !username.valid }">
         <label for="username">Email</label>
-        <input type="email" class="form-control" name="username" [(ngModel)]="model.username" #username="ngModel" required />
-        <div *ngIf="f.submitted && !username.valid" class="help-block">Username is required</div>
+        <input type="email" class="form-control" name="username" [(ngModel)]="model.username" #username="ngModel" required email />
+        <div *ngIf="f.submitted && username.errors?.required" class="help-text">Email is required</div>
+        <p *ngIf="f.submitted && username.errors?.email && !username.errors?.required" class="help-text">Please enter an email address</p>
       </div>
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !password.valid }">
         <label for="password">Password</label>
         <input type="password" class="form-control" name="password" [(ngModel)]="model.password" #password="ngModel" required />
-        <div *ngIf="f.submitted && !password.valid" class="help-block">Password is required</div>
+        <div *ngIf="f.submitted && !password.valid" class="help-text">Password is required</div>
       </div>
       <div class="c-button-container form-group">
         <button type="button" (click)="triggerRegister()" class="c-button -secondary">Register</button>

--- a/src/app/pages/observations/observation-detail-edit.component.html
+++ b/src/app/pages/observations/observation-detail-edit.component.html
@@ -5,7 +5,7 @@
       <form name="form" (ngSubmit)="f.valid && onSubmit(f.value, $event)" #f="ngForm" novalidate>
         <div class="c-container -j-between -t-d-column -t-a-start">
           <h2>{{titleText}}</h2>
-          <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+          <div class="c-button-container -j-end form-group" *otpMinTablet>
             <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
             <button disable="loading" type="submit" class="c-button -primary">Update</button>
           </div>
@@ -131,14 +131,14 @@
               <input id="evidence" type="text" class="form-control" name="evidence" [(ngModel)]="observation && observation.evidence" #evidence="ngModel"  />
           </div>
         </div>
-        <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+        <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
           <div class="c-button-container -j-end form-group">
             <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
             <button disable="loading" type="submit" class="c-button -primary">Update</button>
           </div>
         </div>
 
-        <otp-action-bar *xs>
+        <otp-action-bar *otpMaxTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Update</button>
         </otp-action-bar>

--- a/src/app/pages/observations/observation-detail.component.html
+++ b/src/app/pages/observations/observation-detail.component.html
@@ -5,7 +5,7 @@
       <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
         <div class="c-container -j-between -t-d-column -t-a-start">
           <h2>{{titleText}}</h2>
-          <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+          <div class="c-button-container -j-end form-group" *otpMinTablet>
             <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
             <button disable="loading" type="submit" class="c-button -primary">Create</button>
           </div>
@@ -125,14 +125,14 @@
               <input id="evidence" type="text" class="form-control" name="evidence" ngModel #evidence="ngModel"  />
           </div>
         </div>
-        <div class="c-container -j-end -t-d-column -t-a-start" *showItSizes="{min: 768}">
+        <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
           <div class="c-button-container -j-end form-group">
             <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
             <button disable="loading" type="submit" class="c-button -primary">Create</button>
           </div>
         </div>
 
-        <otp-action-bar *xs>
+        <otp-action-bar *otpMaxTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">Create</button>
         </otp-action-bar>

--- a/src/app/pages/users/user-detail.component.html
+++ b/src/app/pages/users/user-detail.component.html
@@ -5,7 +5,7 @@
       <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
         <div class="c-container -j-between">
           <h2>{{mode === 'new' ? 'New' : 'Update'}} user</h2>
-          <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+          <div class="c-button-container -j-end form-group" *otpMinTablet>
             <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
             <button disable="loading" type="submit" class="c-button -primary">{{mode === 'new' ? 'Create' : 'Update'}}</button>
           </div>
@@ -65,12 +65,12 @@
           </select>
         </div>
 
-        <div class="c-button-container -j-end form-group" *showItSizes="{min: 768}">
+        <div class="c-button-container -j-end form-group" *otpMinTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">{{mode === 'new' ? 'Create' : 'Update'}}</button>
         </div>
 
-        <otp-action-bar *xs>
+        <otp-action-bar *otpMaxTablet>
           <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
           <button disable="loading" type="submit" class="c-button -primary">{{mode === 'new' ? 'Create' : 'Update'}}</button>
         </otp-action-bar>

--- a/src/app/services/responsive.service.ts
+++ b/src/app/services/responsive.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/fromEvent';
+import 'rxjs/add/operator/debounceTime';
+import 'rxjs/add/operator/defaultIfEmpty';
+import 'rxjs/add/operator/startWith';
+
+@Injectable()
+export class ResponsiveService {
+
+  private resize$: Observable<number>;
+
+  get onResize() {
+    return this.resize$;
+  }
+
+  constructor() {
+    this.resize$ = Observable.fromEvent(window, 'resize')
+      .debounceTime(300)
+      .defaultIfEmpty()
+      .startWith(window.innerWidth)
+      .map(() => window.innerWidth);
+  }
+
+}

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -7,6 +7,6 @@
     </ul>
   </div>
   <ng-template [ngIf]="isLogged">
-    <otp-navigation [items]="navigationItems" (change)="onChange($event)" *showItSizes="{min: 768}"></otp-navigation>
+    <otp-navigation [items]="navigationItems" (change)="onChange($event)" *otpMinTablet></otp-navigation>
   </ng-template>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,7 +441,7 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.6.1:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -545,7 +545,7 @@ blocking-proxy@0.0.5:
   dependencies:
     minimist "^1.2.0"
 
-bluebird@^3.3.0, bluebird@^3.4.6, bluebird@^3.4.7:
+bluebird@^3.3.0, bluebird@^3.4.7:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
@@ -2861,15 +2861,6 @@ less@^2.7.2:
     request "^2.72.0"
     source-map "^0.5.3"
 
-libphonenumber-js@^0.4.5:
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-0.4.10.tgz#8d64813675742074c01037a6ea266c1b394336c3"
-  dependencies:
-    babel-runtime "^6.6.1"
-    bluebird "^3.4.6"
-    minimist "^1.2.0"
-    xml2js "^0.4.17"
-
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3178,12 +3169,6 @@ ng2-datepicker@^1.8.3:
 ng2-slimscroll@^1.2.6:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/ng2-slimscroll/-/ng2-slimscroll-1.3.2.tgz#8b052ca8748080ecce8138f1ab5826beaddf5d49"
-
-ng2-validation@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ng2-validation/-/ng2-validation-4.2.0.tgz#f38d441d3fb7e862155166480045aaff9ad11dbb"
-  dependencies:
-    libphonenumber-js "^0.4.5"
 
 no-case@^2.2.0:
   version "2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,6 +170,10 @@ acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
+acorn@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
+
 adm-zip@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.4.tgz#a61ed5ae6905c3aea58b3a657d25033091052736"
@@ -927,7 +931,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.x:
+commander@2.9.x, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1431,6 +1435,10 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -1440,6 +1448,10 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+ejs@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.6.tgz#479636bfa3fe3b1debd52087f0acb204b4f19c88"
 
 electron-to-chromium@^1.2.7:
   version "1.3.9"
@@ -1741,6 +1753,10 @@ fileset@^2.0.2:
     glob "^7.0.3"
     minimatch "^3.0.3"
 
+filesize@^3.5.9:
+  version "3.5.9"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.9.tgz#9e3dd8a9b124f5b2f1fb2ee9cd13a86c707bb222"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -2015,6 +2031,12 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+gzip-size@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
+  dependencies:
+    duplexer "^0.1.1"
 
 handle-thing@^1.2.4:
   version "1.2.5"
@@ -3153,10 +3175,6 @@ ng2-datepicker@^1.8.3:
     moment "^2.17.1"
     ng2-slimscroll "^1.2.6"
 
-ng2-responsive@^0.8.3:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/ng2-responsive/-/ng2-responsive-0.8.4.tgz#b99151258a981a1a41a3ec8673df0291005578cf"
-
 ng2-slimscroll@^1.2.6:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/ng2-slimscroll/-/ng2-slimscroll-1.3.2.tgz#8b052ca8748080ecce8138f1ab5826beaddf5d49"
@@ -3382,6 +3400,10 @@ onetime@^2.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   dependencies:
     mimic-fn "^1.0.0"
+
+opener@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
 opn@4.0.2:
   version "4.0.2"
@@ -4257,7 +4279,7 @@ rxjs@^5.0.1, rxjs@^5.1.0:
   dependencies:
     symbol-observable "^1.0.1"
 
-safe-buffer@^5.0.1:
+safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
@@ -4959,6 +4981,10 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+ultron@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -5164,6 +5190,22 @@ webdriver-manager@^12.0.1:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
+webpack-bundle-analyzer@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.8.1.tgz#f452a5e4ae0cd8144d8b0347f2c3c644310daedd"
+  dependencies:
+    acorn "^5.0.3"
+    chalk "^1.1.3"
+    commander "^2.9.0"
+    ejs "^2.5.6"
+    express "^4.15.2"
+    filesize "^3.5.9"
+    gzip-size "^3.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    opener "^1.4.3"
+    ws "^2.3.1"
+
 webpack-dev-middleware@^1.0.11, webpack-dev-middleware@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz#2e252ce1dfb020dbda1ccb37df26f30ab014dbd1"
@@ -5314,6 +5356,13 @@ ws@1.1.1, ws@^1.0.1:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
+
+ws@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
+  dependencies:
+    safe-buffer "~5.0.1"
+    ultron "~1.1.0"
 
 wtf-8@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR shrinks the size of the vendor bundle by 901kB (~25%).

To achieve this result, two dependencies have been removed.

First, we've removed `ng2-responsive`. We were using just a small part of it and it would require the whole `rxjs` library as a dependency. Instead, I've created our own directives, `otpMaxTablet` and `otpMinTablet`, to keep having dynamic components that show or hide depending on the viewport's size. With this change, we've saved 624kB.

Then we've removed `ng2-validation`. The issue with the library is that it would include `libphonenumber-js` as a dependency whereas we don't need it. We've saved 276kB with this change. The alternative was to create, once again, our own directives.

In the future, we can further save about 300kB by removing `moment` and `lodash` from the dependencies of `angular2-jsonapi`. It seems the library isn't supported anymore but [I've already created a fork](https://github.com/clementprdhomme/angular2-jsonapi) of it in which I've removed `moment` (in a local branch).

In addition, we should be able to speed up the loading time of the app by splitting the code by route. I think we could split the app in 3 bundles:
- login and register
- observations
- fields
- (my OTP)