### PR TITLE
Feature/i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "prod-build": "for lang in en fr; do ng build --output-path=dist/$lang --base-href=/observations-tool --aot -prod --i18n-file=src/locale/messages.$lang.xlf --i18n-format=xlf --locale=$lang; done",
-    "i18n": "for lang in en fr; do ng xi18n --output-path ./src/locale/ --out-file messages.$lang.xlf --progress --locale en; done",
+    "extract-i18n": "ng xi18n --output-path src/locale/ --locale en && xliffmerge --profile xliffmerge.json en fr",
+    "start-en": "ng serve --aot --i18n-file=src/locale/messages.en.xlf --locale=en --i18n-format=xlf",
+    "start-fr": "ng serve --aot --i18n-file=src/locale/messages.fr.xlf --locale=fr --i18n-format=xlf",
     "bundle-report": "webpack-bundle-analyzer dist/stats.json"
   },
   "private": true,
@@ -49,6 +51,7 @@
     "karma-coverage-istanbul-reporter": "^0.2.0",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "ngx-i18nsupport": "^0.6.1",
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "prod-build": "ng build --prod --aot --extract-css --base-href '/observations-tool'",
+    "prod-build": "for lang in en fr; do ng build --output-path=dist/$lang --base-href=/observations-tool --aot -prod --i18n-file=src/locale/messages.$lang.xlf --i18n-format=xlf --locale=$lang; done",
+    "i18n": "for lang in en fr; do ng xi18n --output-path ./src/locale/ --out-file messages.$lang.xlf --progress --locale en; done",
     "bundle-report": "webpack-bundle-analyzer dist/stats.json"
   },
   "private": true,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,3 +1,4 @@
+import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 import { Component, LOCALE_ID, Inject } from '@angular/core';
 import { AuthService } from 'app/services/auth.service';
 
@@ -9,12 +10,31 @@ import { AuthService } from 'app/services/auth.service';
 export class AppComponent {
   isLogged = false;
 
-  constructor(private authService: AuthService, @Inject(LOCALE_ID) private locale: string) {
+  constructor(
+    private authService: AuthService,
+    private router: Router,
+    private route: ActivatedRoute,
+    @Inject(LOCALE_ID) private locale: string
+  ) {
     this.authService.loginStatus.subscribe(isLogged => this.isLogged = isLogged);
     this.setHTMLLangAttribute();
+
+    this.router.events.subscribe(e => {
+      if (e instanceof NavigationEnd && !this.route.snapshot.queryParams['lang']) {
+        this.addLocaleToURL();
+      }
+    });
   }
 
   setHTMLLangAttribute(): void {
     document.documentElement.lang = this.locale.slice(0, 2);
+  }
+
+  addLocaleToURL(): void {
+    this.router.navigate([], {
+      queryParams: { lang: this.locale.slice(0, 2) },
+      replaceUrl: true,
+      relativeTo: this.route
+    });
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, LOCALE_ID, Inject } from '@angular/core';
 import { AuthService } from 'app/services/auth.service';
 
 @Component({
@@ -9,7 +9,12 @@ import { AuthService } from 'app/services/auth.service';
 export class AppComponent {
   isLogged = false;
 
-  constructor(private authService: AuthService) {
+  constructor(private authService: AuthService, @Inject(LOCALE_ID) private locale: string) {
     this.authService.loginStatus.subscribe(isLogged => this.isLogged = isLogged);
+    this.setHTMLLangAttribute();
+  }
+
+  setHTMLLangAttribute(): void {
+    document.documentElement.lang = this.locale.slice(0, 2);
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { NavigationItemDirective } from 'app/shared/navigation/directives/item/item.directive';
 import { PageNotFoundComponent } from 'app/pages/page-not-found/page-not-found.component';
 import { LoaderComponent } from 'app/shared/loader/loader.component';
 import { ObservationsComponent } from 'app/pages/observations/observations.component';
@@ -93,6 +94,7 @@ import { MaxTabletDirective, MinTabletDirective } from 'app/directives/responsiv
     FieldDetailComponent,
     TabsComponent,
     NavigationComponent,
+    NavigationItemDirective,
     HeaderComponent,
     GovernmentListComponent,
     GovernmentDetailComponent,

--- a/src/app/pages/fields/categories/category-detail.component.html
+++ b/src/app/pages/fields/categories/category-detail.component.html
@@ -1,32 +1,35 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 <div class="c-container -j-between -t-d-column -t-a-start">
-  <h2>{{titleText}}</h2>
+  <h2>
+    <ng-template [ngIf]="mode === 'new'" i18n="Category creation|Title of the page">New category</ng-template>
+    <ng-template [ngIf]="mode !== 'new'" i18n="Category edition|Title of the page">Update category</ng-template>
+  </h2>
   <div class="c-button-container -j-end form-group" *otpMinTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Create</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
   </div>
 </div>
 
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !name.valid }">
-      <label for="name">Name</label>
+      <label for="name" i18n="Category creation/edition|Label for the name field">Name</label>
       <input id="name" type="text" class="form-control" name="name" ngModel #name="ngModel" required />
-      <div *ngIf="f.submitted && !name.valid" class="help-text">Name is required</div>
+      <div *ngIf="f.submitted && !name.valid" class="help-text" i18n="Category creation/edition|Error message if the name isn't supplied">Name is required</div>
     </div>
   </div>
 
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 </form>

--- a/src/app/pages/fields/categories/category-detail.component.ts
+++ b/src/app/pages/fields/categories/category-detail.component.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
 })
 export class CategoryDetailComponent {
 
-  titleText: String = 'New Category';
+  mode: String = 'new';
   loading = false;
 
   constructor(

--- a/src/app/pages/fields/categories/category-list.component.html
+++ b/src/app/pages/fields/categories/category-list.component.html
@@ -1,14 +1,14 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-button-container -j-end">
-    <button (click)="triggerNewCategory()" class="c-button -primary">
+    <button (click)="triggerNewCategory()" class="c-button -primary" i18n="Button to create a new category">
       New Category
     </button>
   </div>
 </div>
 
-<otp-table caption="Categories">
-  <otp-table-column prop="name" name="Name"></otp-table-column>
-  <otp-table-column name="Actions">
+<otp-table i18n-caption="Caption for the table which lists the categories" caption="Categories">
+  <otp-table-column i18n-name="Table of categories|Name of the column corresponding to the name of the categories" prop="name" name="Name"></otp-table-column>
+  <otp-table-column i18n-name="Table of categories|Name of the actions columns (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/pages/fields/countries/country-detail.component.html
+++ b/src/app/pages/fields/countries/country-detail.component.html
@@ -1,48 +1,51 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 <div class="c-container -j-between -t-d-column -t-a-start">
-  <h2>{{titleText}}</h2>
+  <h2>
+    <ng-template [ngIf]="mode === 'new'" i18n="Country creation|Title of the page">New country</ng-template>
+    <ng-template [ngIf]="mode !== 'new'" i18n="Country edition|Title of the page">Update country</ng-template>
+  </h2>
   <div class="c-button-container -j-end form-group" *otpMinTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Create</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
   </div>
 </div>
 
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !name.valid }">
-      <label for="name">Name</label>
+      <label for="name" i18n="Country creation/edition|Label for the name field">Name</label>
       <input id="name" type="text" class="form-control" name="name" ngModel #name="ngModel" required />
-      <div *ngIf="f.submitted && !name.valid" class="help-text">Name is required</div>
+      <div *ngIf="f.submitted && !name.valid" class="help-text" i18n="Country creation/edition|Error message if the name isn't supplied">Name is required</div>
     </div>
 
     <div class="form-group">
-      <label for="region_name">Region name</label>
+      <label for="region_name" i18n="Country creation/edition|Label for the region name field">Region name</label>
       <input id="region_name" type="text" class="form-control" name="region_name" ngModel #region_name="ngModel" />
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !iso.valid }">
-      <label for="iso">ISO</label>
+      <label for="iso" i18n="Country creation/edition|Label for the ISO code field">ISO</label>
       <input id="iso" type="text" class="form-control" name="iso" ngModel #iso="ngModel" required />
-      <div *ngIf="f.submitted && !iso.valid" class="help-text">ISO is required</div>
+      <div *ngIf="f.submitted && !iso.valid" class="help-text" i18n="Country creation/edition|Error message if the ISO code isn't supplied">ISO is required</div>
     </div>
 
     <div class="form-group">
-      <label for="region_iso">Region ISO</label>
+      <label for="region_iso" i18n="Country creation/edition|Label for the region ISO code field">Region ISO</label>
       <input id="region_iso" type="text" class="form-control" name="region_iso" ngModel #region_iso="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="country_centroid">Country centroid</label>
+      <label for="country_centroid" i18n="Country creation/edition|Label for the country centroid field">Country centroid</label>
       <input id="country_centroid" type="text" class="form-control" name="country_centroid" ngModel #country_centroid="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="region_centroid">Region centroid</label>
+      <label for="region_centroid" i18n="Country creation/edition|Label for the region centroid field">Region centroid</label>
       <input id="region_centroid" type="text" class="form-control" name="region_centroid" ngModel #region_centroid="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="is_active">Available for observations?</label>
+      <label for="is_active" i18n="Country creation/edition|Label for the field that let the user select if the country will be available for observations">Available for observations?</label>
       <input id="is_active" type="checkbox" name="is_active" ngModel #is_active="ngModel" />
     </div>
   </div>
@@ -50,14 +53,14 @@
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 </form>

--- a/src/app/pages/fields/countries/country-detail.component.ts
+++ b/src/app/pages/fields/countries/country-detail.component.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
 })
 export class CountryDetailComponent {
 
-  titleText: String = 'New Country';
+  mode: String = 'new';
   loading = false;
 
   constructor(

--- a/src/app/pages/fields/countries/country-list.component.html
+++ b/src/app/pages/fields/countries/country-list.component.html
@@ -1,17 +1,17 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-button-container -j-end">
-    <button (click)="triggerNewCountry()" class="c-button -primary">
+    <button (click)="triggerNewCountry()" class="c-button -primary" i18n="Button to create a new country">
       New Country
     </button>
   </div>
 </div>
 
-<otp-table caption="Countries">
-  <otp-table-column prop="name" name="Name"></otp-table-column>
-  <otp-table-column prop="iso" name="ISO"></otp-table-column>
-  <otp-table-column prop="region_name" name="Region Name"></otp-table-column>
-  <otp-table-column prop="is_active" name="Active"></otp-table-column>
-  <otp-table-column name="Actions">
+<otp-table i18n-caption="Caption for the table which lists the countries" caption="Countries">
+  <otp-table-column i18n-name="Table of countries|Name of the column corresponding to the name of the countries" prop="name" name="Name"></otp-table-column>
+  <otp-table-column i18n-name="Table of countries|Name of the column corresponding to the ISO code of the countries" prop="iso" name="ISO"></otp-table-column>
+  <otp-table-column i18n-name="Table of countries|Name of the column corresponding to the region name of the countries" prop="region_name" name="Region Name"></otp-table-column>
+  <otp-table-column i18n-name="Table of countries|Name of the column corresponding to whether or not the countries are active" prop="is_active" name="Active"></otp-table-column>
+  <otp-table-column i18n-name="Table of countries|Name of the actions columns (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/pages/fields/field-list.component.html
+++ b/src/app/pages/fields/field-list.component.html
@@ -1,9 +1,27 @@
 <div class="mobile-navigation" *otpMaxTablet>
-  <otp-navigation [items]="navigationItems" layout="horizontal"></otp-navigation>
+  <otp-navigation layout="horizontal">
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Categories" url="categories"></otp-navigation-item>
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Sub-categories" url="subcategories"></otp-navigation-item>
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Species" url="species"></otp-navigation-item>
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Countries" url="countries"></otp-navigation-item>
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Governments" url="governments"></otp-navigation-item>
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Operators" url="operators"></otp-navigation-item>
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Monitors" url="observers"></otp-navigation-item>
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Laws" url="laws"></otp-navigation-item>
+  </otp-navigation>
 </div>
 <div class="l-wrapper">
   <div class="c-container -j-start -a-start">
-    <otp-navigation *otpMinTablet [items]="navigationItems" layout="vertical"></otp-navigation>
+    <otp-navigation *otpMinTablet layout="vertical">
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Categories" url="categories"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Sub-categories" url="subcategories"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Species" url="species"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Countries" url="countries"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Governments" url="governments"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Operators" url="operators"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Monitors" url="observers"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations fields' page" name="Laws" url="laws"></otp-navigation-item>
+    </otp-navigation>
     <div class="content">
       <router-outlet ></router-outlet>
     </div>

--- a/src/app/pages/fields/field-list.component.ts
+++ b/src/app/pages/fields/field-list.component.ts
@@ -6,17 +6,4 @@ import { NavigationItem } from 'app/shared/navigation/navigation.component';
   templateUrl: './field-list.component.html',
   styleUrls: ['./field-list.component.scss']
 })
-export class FieldListComponent {
-
-  private navigationItems: NavigationItem[] = [
-    { name: 'Categories', url: 'categories' },
-    { name: 'Sub-categories', url: 'subcategories' },
-    { name: 'Species', url: 'species' },
-    { name: 'Countries', url: 'countries' },
-    { name: 'Governments', url: 'governments' },
-    { name: 'Operators', url: 'operators' },
-    { name: 'Monitors', url: 'observers' },
-    { name: 'Laws', url: 'laws' },
-  ];
-
-}
+export class FieldListComponent {}

--- a/src/app/pages/fields/governments/government-detail.component.html
+++ b/src/app/pages/fields/governments/government-detail.component.html
@@ -1,31 +1,33 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 <div class="c-container -j-between -t-d-column -t-a-start">
-  <h2>{{titleText}}</h2>
+  <h2>
+    <ng-template [ngIf]="mode === 'new'" i18n="Government creation|Title of the page">New government</ng-template>
+    <ng-template [ngIf]="mode !== 'new'" i18n="Government creation|Title of the page">Update government</ng-template>
+  </h2>
   <div class="c-button-container -j-end form-group" *otpMinTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Create</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
   </div>
 </div>
 
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !government_entity.valid }">
-      <label for="government_entity">Government entity</label>
+      <label for="government_entity" i18n="Government creation/edition|Label for the government entity field">Government entity</label>
       <input id="government_entity" type="text" class="form-control" name="government_entity" ngModel #government_entity="ngModel" required />
-      <div *ngIf="f.submitted && !government_entity.valid" class="help-text">Government entity is required</div>
+      <div *ngIf="f.submitted && !government_entity.valid" class="help-text" i18n="Government creation/edition|Error message if the government entity isn't supplied">Government entity is required</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !country_id.valid }">
-      <label for="country_id">Country
-        <select id="country_id" name="country_id" ngModel #country_id="ngModel" required>
-          <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
-        </select>
-      </label>
-      <div *ngIf="f.submitted && !country_id.valid" class="help-text">Please select a country</div>
+      <label for="country_id" i18n="Government creation/edition|Label for the country field">Country</label>
+      <select id="country_id" name="country_id" ngModel #country_id="ngModel" required>
+        <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
+      </select>
+      <div *ngIf="f.submitted && !country_id.valid" class="help-text" i18n="Government creation/edition|Error message if the country isn't supplied (the user will have to choose between serveral options)">Please select a country</div>
     </div>
 
     <div class="form-group">
-      <label for="details">Details</label>
+      <label for="details" i18n="Government creation/edition|Label for the details field">Details</label>
       <input id="details" type="text" class="form-control" name="details" ngModel #details="ngModel" />
     </div>
   </div>
@@ -33,14 +35,14 @@
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 </form>

--- a/src/app/pages/fields/governments/government-detail.component.ts
+++ b/src/app/pages/fields/governments/government-detail.component.ts
@@ -12,7 +12,7 @@ import { Component, OnInit } from '@angular/core';
 export class GovernmentDetailComponent implements OnInit {
 
   countries: Country[] = [];
-  titleText: String = 'New Government';
+  mode: String = 'new';
   loading = false;
 
   constructor(

--- a/src/app/pages/fields/governments/government-list.component.html
+++ b/src/app/pages/fields/governments/government-list.component.html
@@ -1,15 +1,15 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-button-container -j-end">
-    <button (click)="triggerNewGovernment()" class="c-button -primary">
-      New Government Unit
+    <button (click)="triggerNewGovernment()" class="c-button -primary" i18n="Button to create a new government unit">
+      New government unit
     </button>
   </div>
 </div>
 
-<otp-table caption="Governments">
-  <otp-table-column prop="government_entity" name="Name"></otp-table-column>
-  <otp-table-column prop="details" name="Details"></otp-table-column>
-  <otp-table-column name="Actions">
+<otp-table i18n-caption="Caption for the table which lists the governments" caption="Governments">
+  <otp-table-column i18n-name="Table of governments|Name of the column corresponding to the name of the governments" prop="government_entity" name="Name"></otp-table-column>
+  <otp-table-column i18n-name="Table of governments|Name of the column corresponding to the details of the governments" prop="details" name="Details"></otp-table-column>
+  <otp-table-column i18n-name="Table of governments|Name of the actions columns (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/pages/fields/laws/law-detail.component.html
+++ b/src/app/pages/fields/laws/law-detail.component.html
@@ -1,34 +1,36 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 <div class="c-container -j-between -t-d-column -t-a-start">
-  <h2>{{titleText}}</h2>
+  <h2>
+    <ng-template [ngIf]="mode === 'new'" i18n="Law creation|Title of the page">New law</ng-template>
+    <ng-template [ngIf]="mode !== 'new'" i18n="Law edition|Title of the page">Update law</ng-template>
+  </h2>
   <div class="c-button-container -j-end form-group" *otpMinTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Create</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
   </div>
 </div>
 
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !legal_reference.valid }">
-      <label for="legal_reference">Legal reference</label>
+      <label for="legal_reference" i18n="Law creation/edition|Label for the legal reference field">Legal reference</label>
       <input id="legal_reference" type="text" class="form-control" name="legal_reference" ngModel #legal_reference="ngModel" required />
-      <div *ngIf="f.submitted && !legal_reference.valid" class="help-text">Legal reference is required</div>
+      <div *ngIf="f.submitted && !legal_reference.valid" class="help-text" i18n="Law creation/edition|Error message if the legal reference isn't supplied">Legal reference is required</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !country_id.valid }">
-      <label for="country_id">Country
-        <select id="country_id" name="country_id" ngModel #country_id="ngModel" required>
-          <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
-        </select>
-      </label>
-      <div *ngIf="f.submitted && !country_id.valid" class="help-text">Please select a country</div>
+      <label for="country_id" i18n="Law creation/edition|Label for the country field">Country</label>
+      <select id="country_id" name="country_id" ngModel #country_id="ngModel" required>
+        <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
+      </select>
+      <div *ngIf="f.submitted && !country_id.valid" class="help-text" i18n="Law creation/edition|Error message if the country isn't supplied (the user will have to choose between some options)">Please select a country</div>
     </div>
     <div class="form-group">
-      <label for="vpa_indicator">VPA indicator</label>
+      <label for="vpa_indicator" i18n="Law creation/edition|Label for the VPA indicator field">VPA indicator</label>
       <input id="vpa_indicator" type="text" class="form-control" name="vpa_indicator" ngModel #vpa_indicator="ngModel" />
     </div>
     <div class="form-group">
-      <label for="legal_penalty">Legal penalty</label>
+      <label for="legal_penalty" i18n="Law creation/edition|Label for the legal penalty field">Legal penalty</label>
       <input id="legal_penalty" type="text" class="form-control" name="legal_penalty" ngModel #legal_penalty="ngModel" />
     </div>
   </div>
@@ -36,14 +38,14 @@
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 </form>

--- a/src/app/pages/fields/laws/law-detail.component.ts
+++ b/src/app/pages/fields/laws/law-detail.component.ts
@@ -12,7 +12,7 @@ import { Component, OnInit } from '@angular/core';
 export class LawDetailComponent implements OnInit {
 
   countries: Country[];
-  titleText: String = 'New Law';
+  mode: String = 'new';
   loading = false;
 
   constructor(

--- a/src/app/pages/fields/laws/law-list.component.html
+++ b/src/app/pages/fields/laws/law-list.component.html
@@ -1,19 +1,19 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-button-container -j-end">
-    <button (click)="triggerNewLaw()" class="c-button -primary">
+    <button (click)="triggerNewLaw()" class="c-button -primary" i18n="Button to create a new law">
       New law
     </button>
   </div>
 </div>
 
-<otp-table caption="Laws">
-  <otp-table-column prop="legal_reference" name="Legal Reference">
+<otp-table i18n-caption="Caption for the table which lists the laws" caption="Laws">
+  <otp-table-column i18n-name="Table of laws|Name of the column corresponding to the legal reference of the laws" prop="legal_reference" name="Legal Reference">
   </otp-table-column>
-  <otp-table-column prop="legal_penalty" name="Legal Penalty">
+  <otp-table-column i18n-name="Table of laws|Name of the column corresponding to the legal penalty of the laws" prop="legal_penalty" name="Legal Penalty">
   </otp-table-column>
-  <otp-table-column prop="vpa_indicator" name="VPA indicator">
+  <otp-table-column i18n-name="Table of laws|Name of the column corresponding to the VPA indicator of the laws" prop="vpa_indicator" name="VPA indicator">
   </otp-table-column>
-  <otp-table-column name="Actions">
+  <otp-table-column i18n-name="Table of laws|Name of the actions (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/pages/fields/observers/observer-detail.component.html
+++ b/src/app/pages/fields/observers/observer-detail.component.html
@@ -1,48 +1,49 @@
 <spinner *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 
 <div class="c-container -j-between -t-d-column -t-a-start">
-  <h2>{{titleText}}</h2>
+  <h2>
+    <ng-template [ngIf]="mode === 'new'" i18n="Monitor creation|Title of the page">New monitor</ng-template>
+    <ng-template [ngIf]="mode !== 'new'" i18n="Monitor edition|Title of the page">Update monitor</ng-template>
+  </h2>
   <div class="c-button-container -j-end form-group" *otpMinTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Create</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
   </div>
 </div>
 
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !name.valid }">
-      <label for="name">Name</label>
+      <label for="name" i18n="Monitor creation/edition|Label for the name field">Name</label>
       <input id="name" type="text" class="form-control" name="name" ngModel #name="ngModel" required />
-      <div *ngIf="f.submitted && !name.valid" class="help-text">Name is required</div>
+      <div *ngIf="f.submitted && !name.valid" class="help-text" i18n="Monitor creation/edition|Error message if the name isn't supplied">Name is required</div>
     </div>
 
     <div class="form-group">
-      <label for="observer_type">Observer type
-        <select id="observer_type" name="observer_type" ngModel #observer_type="ngModel" required>
-            <option selected [value]="'Mandated'">Mandated</option>
-            <option [value]="'SemiMandated'">SemiMandated</option>
-            <option [value]="'External'">External</option>
-            <option [value]="'Government'">Government</option>
-        </select>
-      </label>
-      <div *ngIf="f.submitted && !observer_type.valid" class="help-text">Please select a observer_type</div>
+      <label for="observer_type" i18n="Monitor creation/edition|Label for the monitor type field">Monitor type</label>
+      <select id="observer_type" name="observer_type" ngModel #observer_type="ngModel" required>
+        <option selected value="Mandated" i18n="Type of monitor">Mandated</option>
+        <option value="SemiMandated" i18n="Type of monitor">Semi mandated</option>
+        <option value="External" i18n="Type of monitor">External</option>
+        <option value="Government" i18n="Type of monitor">Government</option>
+      </select>
+      <div *ngIf="f.submitted && !observer_type.valid" class="help-text" i18n="Monitor creation/edition|Error message if the monitor type isn't supplied (the user will have to choose between some options)">Please select a type of monitor</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !country_id.valid }">
-      <label for="country_id">Country
-        <select id="country_id" name="country_id" ngModel #country_id="ngModel">
-          <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
-        </select>
-      </label>
+      <label for="country_id" i18n="Monitor creation/edition|Label for the country field">Country</label>
+      <select id="country_id" name="country_id" ngModel #country_id="ngModel">
+        <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
+      </select>
     </div>
 
     <div class="form-group">
-      <label for="organization">Organization</label>
+      <label for="organization" i18n="Monitor creation/edition|Label for the organization's name field">Organization</label>
       <input id="organization" type="text" class="form-control" name="organization" ngModel #organization="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="active">Active</label>
+      <label for="active" i18n="Monitor creation/edition|Label for the field to tell whether the monitor is active or not">Active</label>
       <input id="active" type="checkbox" name="active" ngModel #active="ngModel" />
     </div>
   </div>
@@ -50,14 +51,14 @@
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 </form>

--- a/src/app/pages/fields/observers/observer-detail.component.ts
+++ b/src/app/pages/fields/observers/observer-detail.component.ts
@@ -12,7 +12,7 @@ import { Component, OnInit } from '@angular/core';
 export class ObserverDetailComponent implements OnInit {
 
   countries: Country[] = [];
-  titleText: String = 'New Monitor';
+  mode: String = 'new';
   loading: boolean;
 
   constructor(

--- a/src/app/pages/fields/observers/observer-list.component.html
+++ b/src/app/pages/fields/observers/observer-list.component.html
@@ -1,18 +1,18 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-button-container -j-end">
-    <button (click)="triggerNewObserver()" class="c-button -primary">
+    <button (click)="triggerNewObserver()" class="c-button -primary" i18n="Button to create a new monitor">
       New Monitor
     </button>
   </div>
 </div>
 
 <otp-table caption="Monitors">
-  <otp-table-column prop="publication_date" name="Date"></otp-table-column>
-  <otp-table-column prop="name" name="Name"></otp-table-column>
-  <otp-table-column prop="observer_type" name="Type"></otp-table-column>
-  <otp-table-column prop="organization" name="Organization"></otp-table-column>
-  <otp-table-column prop="active" name="Active"></otp-table-column>
-  <otp-table-column name="Actions">
+  <otp-table-column i18n-name="Table of monitors|Name of the column corresponding to the date of the monitors" prop="publication_date" name="Date"></otp-table-column>
+  <otp-table-column i18n-name="Table of monitors|Name of the column corresponding to the name of the monitors" prop="name" name="Name"></otp-table-column>
+  <otp-table-column i18n-name="Table of monitors|Name of the column corresponding to the type of monitors" prop="observer_type" name="Type"></otp-table-column>
+  <otp-table-column i18n-name="Table of monitors|Name of the column corresponding to the organizations of the monitors" prop="organization" name="Organization"></otp-table-column>
+  <otp-table-column i18n-name="Table of monitors|Name of the column corresponding to the whether the monitors are active or not" prop="active" name="Active"></otp-table-column>
+  <otp-table-column i18n-name="Table of monitors|Name of the actions columns (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/pages/fields/operators/operator-detail.component.html
+++ b/src/app/pages/fields/operators/operator-detail.component.html
@@ -1,57 +1,58 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 <div class="c-container -j-between -t-d-column -t-a-start">
-  <h2>{{titleText}}</h2>
+  <h2>
+    <ng-template [ngIf]="mode === 'new'" i18n="Operator creation|Title of the page">New operator</ng-template>
+    <ng-template [ngIf]="mode !== 'new'" i18n="Operator creation|Title of the page">Update operator</ng-template>
+  </h2>
   <div class="c-button-container -j-end form-group" *otpMinTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Create</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
   </div>
 </div>
 
 <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !name.valid }">
-      <label for="name">Name</label>
+      <label for="name" i18n="Operator creation/edition|Label for the name field">Name</label>
       <input id="name" type="text" class="form-control" name="name" ngModel #name="ngModel" required />
-      <div *ngIf="f.submitted && !name.valid" class="help-text">Name is required</div>
+      <div *ngIf="f.submitted && !name.valid" class="help-text" i18n="Operator creation/edition|Error message if the name isn't supplied">Name is required</div>
     </div>
 
     <div class="form-group">
-      <label for="operator_type">Operator type
-        <select id="operator_type" name="operator_type" ngModel #operator_type="ngModel" required>
-            <option selected [value]="'Logging'">Logging</option>
-            <option [value]="'Company'">Company</option>
-            <option [value]="'Artisanal'">Artisanal</option>
-            <option [value]="'Sawmill'">Sawmill</option>
-            <option [value]="'CommunityForest'">Community Forest</option>
-            <option [value]="'ARB1327'">ARB1327</option>
-            <option [value]="'PalmOil'">Palm Oil</option>
-            <option [value]="'Trader'">Trader</option>
-            <option [value]="'Company'">Company</option>
-        </select>
-      </label>
-      <div *ngIf="f.submitted && !operator_type.valid" class="help-text">Please select a operator_type</div>
+      <label for="operator_type" i18n="Operator creation/edition|Label for the operator type field">Operator type</label>
+      <select id="operator_type" name="operator_type" ngModel #operator_type="ngModel" required>
+        <option selected value="Logging" i18n="Operator type">Logging</option>
+        <option value="Company" i18n="Operator type">Company</option>
+        <option value="Artisanal" i18n="Operator type">Artisanal</option>
+        <option value="Sawmill" i18n="Operator type">Sawmill</option>
+        <option value="CommunityForest" i18n="Operator type">Community Forest</option>
+        <option value="ARB1327" i18n="Operator type">ARB1327</option>
+        <option value="PalmOil" i18n="Operator type">Palm Oil</option>
+        <option value="Trader" i18n="Operator type">Trader</option>
+        <option value="Company" i18n="Operator type">Company</option>
+      </select>
+      <div *ngIf="f.submitted && !operator_type.valid" class="help-text" i18n="Operator creation/edition|Error message if the operator type isn't supplied (the user will have to choose between several options)">Please select an operator type</div>
     </div>
 
-    <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !country_id.valid }">
-      <label for="country_id">Country
-        <select id="country_id" name="country_id" ngModel #country_id="ngModel">
-          <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
-        </select>
-      </label>
+    <div class="form-group" i18n="Operator creation/edition|Label for the country field">
+      <label for="country_id">Country</label>
+      <select id="country_id" name="country_id" ngModel #country_id="ngModel">
+        <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
+      </select>
     </div>
 
     <div class="form-group">
-      <label for="concession">Concession</label>
+      <label for="concession" i18n="Operator creation/edition|Label for the concession field">Concession</label>
       <input id="concession" type="text" class="form-control" name="concession" ngModel #concession="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="country_centroid">Country centroid</label>
+      <label for="country_centroid" i18n="Operator creation/edition|Label for the country centroid field">Country centroid</label>
       <input id="country_centroid" type="text" class="form-control" name="country_centroid" ngModel #country_centroid="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="active">Active</label>
+      <label for="active" i18n="Operator creation/edition|Label for the field to tell whether the operator is active or not">Active</label>
       <input id="active" type="checkbox" name="active" ngModel #active="ngModel" />
     </div>
   </div>
@@ -59,14 +60,14 @@
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 </form>

--- a/src/app/pages/fields/operators/operator-detail.component.ts
+++ b/src/app/pages/fields/operators/operator-detail.component.ts
@@ -12,7 +12,7 @@ import { Component, OnInit } from '@angular/core';
 export class OperatorDetailComponent implements OnInit {
 
   countries: Country[] = [];
-  titleText: String = 'New Operator';
+  mode: String = 'new';
   loading: boolean;
 
   constructor(

--- a/src/app/pages/fields/operators/operator-list.component.html
+++ b/src/app/pages/fields/operators/operator-list.component.html
@@ -1,17 +1,17 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-button-container -j-end">
-    <button (click)="triggerNewOperator()" class="c-button -primary">
+    <button (click)="triggerNewOperator()" class="c-button -primary" i18n="Button to create a new operator">
       New Operator
     </button>
   </div>
 </div>
 
-<otp-table caption="Operators">
-  <otp-table-column prop="name" name="Name"></otp-table-column>
-  <otp-table-column prop="operator_type" name="Type"></otp-table-column>
-  <otp-table-column prop="concession" name="Concession"></otp-table-column>
-  <otp-table-column prop="is_active" name="Active"></otp-table-column>
-  <otp-table-column name="Actions">
+<otp-table i18n-caption="Caption for the table which lists the operators" caption="Operators">
+  <otp-table-column i18n-name="Table of operators|Name of the column corresponding to the name of the operators" name="Name" prop="name" prop="name" name="Name"></otp-table-column>
+  <otp-table-column i18n-name="Table of operators|Name of the column corresponding to the type of the operators" prop="operator_type" name="Type"></otp-table-column>
+  <otp-table-column i18n-name="Table of operators|Name of the column corresponding to the concession of the operators" prop="concession" name="Concession"></otp-table-column>
+  <otp-table-column i18n-name="Table of operators|Name of the column corresponding to the whether or not the operators are active" prop="is_active" name="Active"></otp-table-column>
+  <otp-table-column i18n-name="Table of operators|Name of the actions columns (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/pages/fields/species/species-detail.component.html
+++ b/src/app/pages/fields/species/species-detail.component.html
@@ -1,58 +1,61 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 
 <div class="c-container -j-between -t-d-column -t-a-start">
-  <h2>{{titleText}}</h2>
+  <h2>
+    <ng-template [ngIf]="mode === 'new'" i18n="Species creation|Title of the page">New species</ng-template>
+    <ng-template [ngIf]="mode !== 'new'" i18n="Species edition|Title of the page">Update species</ng-template>
+  </h2>
   <div class="c-button-container -j-end form-group" *otpMinTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Create</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
   </div>
 </div>
 
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !name.valid }">
-      <label for="name">Name</label>
+      <label for="name" i18n="Species creation/edition|Label for the name field">Name</label>
       <input id="name" type="text" class="form-control" name="name" ngModel #name="ngModel" required />
-      <div *ngIf="f.submitted && !name.valid" class="help-text">Name is required</div>
+      <div *ngIf="f.submitted && !name.valid" class="help-text" i18n="Species creation/edition|Error message if the name isn't supplied">Name is required</div>
     </div>
 
     <div class="form-group">
-      <label for="common_name">Common name</label>
+      <label for="common_name" i18n="Species creation/edition|Label for the common name field">Common name</label>
       <input id="common_name" type="text" class="form-control" name="common_name" ngModel #common_name="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="scientific_name">Scientific name</label>
+      <label for="scientific_name" i18n="Species creation/edition|Label for the scientific name field">Scientific name</label>
       <input id="scientific_name" type="text" class="form-control" name="scientific_name" ngModel #scientific_name="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="species_class">Species class</label>
+      <label for="species_class" i18n="Species creation/edition|Label for the species class field">Species class</label>
       <input id="species_class" type="text" class="form-control" name="species_class" ngModel #species_class="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="sub_species">Sub species</label>
+      <label for="sub_species" i18n="Species creation/edition|Label for the sub species field">Sub species</label>
       <input id="sub_species" type="text" class="form-control" name="sub_species" ngModel #sub_species="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="species_family">Species family</label>
+      <label for="species_family" i18n="Species creation/edition|Label for the species family field">Species family</label>
       <input id="species_family" type="text" class="form-control" name="species_family" ngModel #species_family="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="kingdom">Kingdom</label>
+      <label for="kingdom" i18n="Species creation/edition|Label for the kingdom field">Kingdom</label>
       <input id="kingdom" type="text" class="form-control" name="kingdom" ngModel #kingdom="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="cites_status">CITES status</label>
+      <label for="cites_status" i18n="Species creation/edition|Label for the CITES status field">CITES status</label>
       <input id="cites_status" type="text" class="form-control" name="cites_status" ngModel #cites_status="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="iucn_status">IUCN status</label>
+      <label for="iucn_status" i18n="Species creation/edition|Label for the IUCN status field">IUCN status</label>
       <input id="iucn_status" type="text" class="form-control" name="iucn_status" ngModel #iucn_status="ngModel" />
     </div>
 
@@ -64,14 +67,14 @@
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 </form>

--- a/src/app/pages/fields/species/species-detail.component.ts
+++ b/src/app/pages/fields/species/species-detail.component.ts
@@ -15,7 +15,7 @@ export class SpeciesDetailComponent implements OnInit {
   countries: Country[];
   countriesDropdownSettings: any;
   countriesDropdownData: any;
-  titleText: String = 'New Species';
+  mode: String = 'new';
   loading = false;
 
   constructor(

--- a/src/app/pages/fields/species/species-list.component.html
+++ b/src/app/pages/fields/species/species-list.component.html
@@ -1,16 +1,16 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-button-container -j-end">
-    <button (click)="triggerNewSpecies()" class="c-button -primary">
+    <button (click)="triggerNewSpecies()" class="c-button -primary" i18n="Button to create a new species">
       New species
     </button>
   </div>
 </div>
 
-<otp-table caption="Species">
-  <otp-table-column prop="name" name="Name"></otp-table-column>
-  <otp-table-column prop="species_class" name="Species Class"></otp-table-column>
-  <otp-table-column prop="scientific_name" name="Scientific Name"></otp-table-column>
-  <otp-table-column name="Actions">
+<otp-table i18n-caption="Caption for the table which lists the species" caption="Species">
+  <otp-table-column i18n-name="Table of species|Name of the column corresponding to the name of the species" prop="name" name="Name"></otp-table-column>
+  <otp-table-column i18n-name="Table of species|Name of the column corresponding to the species class of the species" prop="species_class" name="Species class"></otp-table-column>
+  <otp-table-column i18n-name="Table of species|Name of the column corresponding to the scientific name of the species" prop="scientific_name" name="Scientific name"></otp-table-column>
+  <otp-table-column i18n-name="Table of species|Name of the actions columns (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/pages/fields/subcategories/governance/annex-governance-detail.component.html
+++ b/src/app/pages/fields/subcategories/governance/annex-governance-detail.component.html
@@ -1,26 +1,29 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 <div class="c-container -j-between -t-d-column -t-a-start">
-  <h2>{{titleText}}</h2>
+  <h2>
+    <ng-template [ngIf]="mode === 'new'" i18n="Governance sub-category creation|Title of the page">New governance sub-category</ng-template>
+    <ng-template [ngIf]="mode !== 'new'" i18n="Governance sub-category edition|Title of the page">Update governance sub-category</ng-template>
+  </h2>
   <div class="c-button-container -j-end form-group" *otpMinTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Create</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
   </div>
 </div>
 
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !governance_pillar.valid }">
-      <label for="governance_pillar">Governance pillar</label>
+      <label for="governance_pillar" i18n="Governance sub-category creation/edition|Label for the governance pillar field">Governance pillar</label>
       <input id="governance_pillar" type="text" class="form-control" name="governance_pillar" ngModel #governance_pillar="ngModel" required />
-      <div *ngIf="f.submitted && !governance_pillar.valid" class="help-text">Governance pillar is required</div>
+      <div *ngIf="f.submitted && !governance_pillar.valid" class="help-text" i18n="Governance sub-category creation/edition|Error message if the governance pillar isn't supplied">Governance pillar is required</div>
     </div>
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !governance_problem.valid }">
-      <label for="governance_problem">Governance problem</label>
+      <label for="governance_problem" i18n="Governance sub-category creation/edition|Label for the governance problem field">Governance problem</label>
       <input id="governance_problem" type="text" class="form-control" name="governance_problem" ngModel #governance_problem="ngModel" required />
-      <div *ngIf="f.submitted && !governance_problem.valid" class="help-text">Governance problem is required</div>
+      <div *ngIf="f.submitted && !governance_problem.valid" class="help-text" i18n="Governance sub-category creation/edition|Error message if the governance problem isn't supplied">Governance problem is required</div>
     </div>
     <div class="form-group">
-      <label for="details">Details</label>
+      <label for="details" i18n="Governance sub-category creation/edition|Label for the details field">Details</label>
       <input id="details" type="text" class="form-control" name="details" ngModel #details="ngModel" />
     </div>
   </div>
@@ -28,14 +31,14 @@
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 </form>

--- a/src/app/pages/fields/subcategories/governance/annex-governance-detail.component.ts
+++ b/src/app/pages/fields/subcategories/governance/annex-governance-detail.component.ts
@@ -12,7 +12,7 @@ import { Component, OnInit } from '@angular/core';
 export class AnnexGovernanceDetailComponent implements OnInit {
 
   private countries: Country[] = [];
-  titleText: String = 'New Annex Governance';
+  mode: String = 'new';
   loading = false;
 
   constructor(

--- a/src/app/pages/fields/subcategories/governance/annex-governance-list.component.html
+++ b/src/app/pages/fields/subcategories/governance/annex-governance-list.component.html
@@ -1,15 +1,15 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-button-container -j-end">
-    <button (click)="triggerNewAnnexGovernance()" class="c-button -primary">
-      New Annex Governance
+    <button (click)="triggerNewAnnexGovernance()" class="c-button -primary" i18n="Button to create a governance sub-category">
+      New governance sub-category
     </button>
   </div>
 </div>
 
-<otp-table caption="Sub-categories (Governance)">
-  <otp-table-column prop="governance_pillar" name="Governance Pillar"></otp-table-column>
-  <otp-table-column prop="governance_problem" name="Governance Problem"></otp-table-column>
-  <otp-table-column name="Actions">
+<otp-table i18n-caption="Caption for the table which lists the governance sub-categories" caption="Sub-categories (Governance)">
+  <otp-table-column i18n-name="Table of governance sub-categories|Name of the column corresponding to the governance pillar of the governance sub-categories" prop="governance_pillar" name="Governance Pillar"></otp-table-column>
+  <otp-table-column i18n-name="Table of governance sub-categories|Name of the column corresponding to the governance problem of the governance sub-categories" prop="governance_problem" name="Governance Problem"></otp-table-column>
+  <otp-table-column i18n-name="Table of governance sub-categories|Name of the actions columns (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/pages/fields/subcategories/operators/annex-operator-detail.component.html
+++ b/src/app/pages/fields/subcategories/operators/annex-operator-detail.component.html
@@ -1,36 +1,39 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 <div class="c-container -j-between -t-d-column -t-a-start">
-  <h2>{{titleText}}</h2>
+  <h2>
+    <ng-template [ngIf]="mode === 'new'" i18n="Operator sub-category creation|Title of the page">New operator sub-category</ng-template>
+    <ng-template [ngIf]="mode !== 'new'" i18n="Operator sub-category edition|Title of the page">Update operator sub-category</ng-template>
+  </h2>
   <div class="c-button-container -j-end form-group" *otpMinTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Create</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
   </div>
 </div>
 
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !illegality.valid }">
-      <label for="illegality">Name</label>
+      <label for="illegality" i18n="Operator sub-category creation/edition|Label for the name field">Name</label>
       <input id="illegality" type="text" class="form-control" name="illegality" ngModel #illegality="ngModel" required />
-      <div *ngIf="f.submitted && !illegality.valid" class="help-text">Name is required</div>
+      <div *ngIf="f.submitted && !illegality.valid" class="help-text" i18n="Operator sub-category creation/edition|Error message if the name isn't supplied">Name is required</div>
     </div>
 
     <div class="form-group">
-      <label for="country_id">Country</label>
+      <label for="country_id" i18n="Operator sub-category creation/edition|Label for the country field">Country</label>
       <select id="country_id" name="country_id" ngModel #country_id="ngModel">
         <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
       </select>
     </div>
 
     <div class="form-group">
-      <label for="law_ids">Law references</label>
+      <label for="law_ids" i18n="Operator sub-category creation/edition|Label for the law references field">Law references</label>
       <select multiple id="law_ids" name="law_ids" ngModel #law_ids="ngModel">
         <option *ngFor="let law of laws" [value]="law.id">{{ law.legal_reference }}</option>
       </select>
     </div>
 
     <div class="form-group">
-      <label for="details">Details</label>
+      <label for="details" i18n="Operator sub-category creation/edition|Label for the details field">Details</label>
       <input id="details" type="text" class="form-control" name="details" ngModel #details="ngModel" />
     </div>
   </div>
@@ -38,14 +41,14 @@
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 </form>

--- a/src/app/pages/fields/subcategories/operators/annex-operator-detail.component.ts
+++ b/src/app/pages/fields/subcategories/operators/annex-operator-detail.component.ts
@@ -15,7 +15,7 @@ export class AnnexOperatorDetailComponent implements OnInit {
 
   countries: Country[] = [];
   laws: Law[] = [];
-  titleText: String = 'New Annex Operator';
+  mode: String = 'new';
   loading = false;
 
   constructor(

--- a/src/app/pages/fields/subcategories/operators/annex-operator-list.component.html
+++ b/src/app/pages/fields/subcategories/operators/annex-operator-list.component.html
@@ -1,15 +1,15 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-button-container -j-end">
-    <button (click)="triggerNewAnnexOperator()" class="c-button -primary">
-      New Annex Operator
+    <button (click)="triggerNewAnnexOperator()" class="c-button -primary" i18n="Button to create a operator sub-category">
+      New operator sub-category
     </button>
   </div>
 </div>
 
-<otp-table caption="Sub-categories (Operators)">
-  <otp-table-column prop="illegality" name="Name"></otp-table-column>
-  <otp-table-column prop="details" name="Details"></otp-table-column>
-  <otp-table-column name="Actions">
+<otp-table i18n-caption="Caption for the table which lists the operator sub-categories" caption="Sub-categories (Operators)">
+  <otp-table-column i18n-name="Table of operator sub-categories|Name of the column corresponding to the name of the operator sub-categories" prop="illegality" name="Name"></otp-table-column>
+  <otp-table-column i18n-name="Table of operator sub-categories|Name of the column corresponding to the detail of the operator sub-categories" prop="details" name="Details"></otp-table-column>
+  <otp-table-column i18n-name="Table of operator sub-categories|Name of the actions columns (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/pages/fields/subcategories/subcategories.component.html
+++ b/src/app/pages/fields/subcategories/subcategories.component.html
@@ -1,5 +1,5 @@
-<otp-navigation
-  layout="mini"
-  [items]="navigationItems"
-></otp-navigation>
+<otp-navigation layout="mini">
+  <otp-navigation-item i18n-name="Menu item|Menu located on the 'Sub-categories' list page" name="Operators" url="operators"></otp-navigation-item>
+  <otp-navigation-item i18n-name="Menu item|Menu located on the 'Sub-categories' list page" name="Governance" url="governance"></otp-navigation-item>
+</otp-navigation>
 <router-outlet></router-outlet>

--- a/src/app/pages/fields/subcategories/subcategories.component.ts
+++ b/src/app/pages/fields/subcategories/subcategories.component.ts
@@ -1,5 +1,4 @@
 import { NavigationItem } from 'app/shared/navigation/navigation.component';
-import { Router } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 
 @Component({
@@ -7,17 +6,4 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './subcategories.component.html',
   styleUrls: ['./subcategories.component.scss']
 })
-export class SubcategoriesComponent {
-
-  navigationItems: NavigationItem[] = [
-      { name: 'Operators', url: 'operators' },
-      { name: 'Governance', url: 'governance' }
-    ];
-
-  constructor(
-    private router: Router
-  ) {
-
-  }
-
-}
+export class SubcategoriesComponent {}

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -1,21 +1,21 @@
 <div class="l-wrapper">
   <div class="login-container">
-    <h2>Login</h2>
+    <h2 i18n="Login page|Title of the page">Login</h2>
     <form name="form" (ngSubmit)="f.form.valid && login()" #f="ngForm" novalidate>
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !username.valid }">
-        <label for="username">Email</label>
+        <label for="username" i18n="Login page|Label for the email field">Email</label>
         <input type="email" id="username" class="form-control" name="username" [(ngModel)]="model.username" #username="ngModel" required email />
-        <div *ngIf="f.submitted && username.errors?.required" class="help-text">Email is required</div>
-        <p *ngIf="f.submitted && username.errors?.email && !username.errors?.required" class="help-text">Please enter an email address</p>
+        <div *ngIf="f.submitted && username.errors?.required" class="help-text" i18n="Login page|Error message if the email isn't supplied">Email is required</div>
+        <p *ngIf="f.submitted && username.errors?.email && !username.errors?.required" class="help-text" i18n="Login page|Error message if the email isn't valid">Please enter an email address</p>
       </div>
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !password.valid }">
-        <label for="password">Password</label>
+        <label for="password" i18n="Login page|Label for the password field">Password</label>
         <input type="password" id="password" class="form-control" name="password" [(ngModel)]="model.password" #password="ngModel" required />
-        <div *ngIf="f.submitted && !password.valid" class="help-text">Password is required</div>
+        <div *ngIf="f.submitted && !password.valid" class="help-text" i18n="Login page|Error message if the password isn't supplied">Password is required</div>
       </div>
       <div class="c-button-container form-group">
-        <button type="button" (click)="triggerRegister()" class="c-button -secondary">Register</button>
-        <button [disabled]="loading" class="c-button -primary">Login</button>
+        <button type="button" (click)="triggerRegister()" class="c-button -secondary" i18n="Button to register">Register</button>
+        <button [disabled]="loading" class="c-button -primary" i18n="Button to log in">Login</button>
         <img *ngIf="loading" src="data:image/gif;base64,R0lGODlhEAAQAPIAAP///wAAAMLCwkJCQgAAAGJiYoKCgpKSkiH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAEAAQAAADMwi63P4wyklrE2MIOggZnAdOmGYJRbExwroUmcG2LmDEwnHQLVsYOd2mBzkYDAdKa+dIAAAh+QQJCgAAACwAAAAAEAAQAAADNAi63P5OjCEgG4QMu7DmikRxQlFUYDEZIGBMRVsaqHwctXXf7WEYB4Ag1xjihkMZsiUkKhIAIfkECQoAAAAsAAAAABAAEAAAAzYIujIjK8pByJDMlFYvBoVjHA70GU7xSUJhmKtwHPAKzLO9HMaoKwJZ7Rf8AYPDDzKpZBqfvwQAIfkECQoAAAAsAAAAABAAEAAAAzMIumIlK8oyhpHsnFZfhYumCYUhDAQxRIdhHBGqRoKw0R8DYlJd8z0fMDgsGo/IpHI5TAAAIfkECQoAAAAsAAAAABAAEAAAAzIIunInK0rnZBTwGPNMgQwmdsNgXGJUlIWEuR5oWUIpz8pAEAMe6TwfwyYsGo/IpFKSAAAh+QQJCgAAACwAAAAAEAAQAAADMwi6IMKQORfjdOe82p4wGccc4CEuQradylesojEMBgsUc2G7sDX3lQGBMLAJibufbSlKAAAh+QQJCgAAACwAAAAAEAAQAAADMgi63P7wCRHZnFVdmgHu2nFwlWCI3WGc3TSWhUFGxTAUkGCbtgENBMJAEJsxgMLWzpEAACH5BAkKAAAALAAAAAAQABAAAAMyCLrc/jDKSatlQtScKdceCAjDII7HcQ4EMTCpyrCuUBjCYRgHVtqlAiB1YhiCnlsRkAAAOwAAAAAAAAAAAA==" />
       </div>
     </form>

--- a/src/app/pages/my-otp/my-otp.component.html
+++ b/src/app/pages/my-otp/my-otp.component.html
@@ -1,10 +1,16 @@
 <div class="mobile-navigation" *otpMaxTablet>
-  <otp-navigation [items]="navigationItems" layout="horizontal"></otp-navigation>
+  <otp-navigation layout="horizontal">
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'My OTP' page" name="Organization profile" url="profile"></otp-navigation-item>
+    <otp-navigation-item i18n-name="Menu item|Menu located on the 'My OTP' page" name="My observations" url="observations"></otp-navigation-item>
+  </otp-navigation>
 </div>
 
 <div class="l-wrapper">
   <div class="c-container -j-start -a-start">
-    <otp-navigation *otpMinTablet [items]="navigationItems" layout="vertical"></otp-navigation>
+    <otp-navigation *otpMinTablet layout="vertical">
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'My OTP' page" name="Organization profile" url="profile"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'My OTP' page" name="My observations" url="observations"></otp-navigation-item>
+    </otp-navigation>
     <div class="content">
       <router-outlet></router-outlet>
     </div>

--- a/src/app/pages/my-otp/my-otp.component.ts
+++ b/src/app/pages/my-otp/my-otp.component.ts
@@ -6,11 +6,4 @@ import { Component } from '@angular/core';
   templateUrl: './my-otp.component.html',
   styleUrls: ['./my-otp.component.scss']
 })
-export class MyOTPComponent {
-
-  navigationItems: NavigationItem[] = [
-    { name: 'Organization profile', url: 'profile' },
-    { name: 'My observations', url: 'observations' },
-  ]
-
-}
+export class MyOTPComponent {}

--- a/src/app/pages/my-otp/profile/organization-profile.component.html
+++ b/src/app/pages/my-otp/profile/organization-profile.component.html
@@ -4,39 +4,39 @@
     <div class="form-container">
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !name.valid }">
-        <label for="name">Name of the organization</label>
+        <label for="name" i18n="Organization profile|Label for the name field (name of the organization)">Name of the organization</label>
         <input type="text" id="name" name="name" ngModel #name="ngModel" required />
-        <div *ngIf="f.submitted && name.errors?.required" class="help-text">Name is required</div>
+        <div *ngIf="f.submitted && name.errors?.required" class="help-text" i18n="Organization profile|Error message if the name of the organization isn't supplied">Name is required</div>
       </div>
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !address.valid }">
-        <label for="address">Address</label>
+        <label for="address" i18n="Organization profile|Label for the address field">Address</label>
         <input type="text" id="address" name="address" ngModel #address="ngModel" required />
-        <div *ngIf="f.submitted && address.errors?.required" class="help-text">Address is required</div>
+        <div *ngIf="f.submitted && address.errors?.required" class="help-text" i18n="Organization profile|Error message if the address isn't supplied">Address is required</div>
       </div>
 
       <fieldset>
-        <legend>Contact information (General information)</legend>
+        <legend i18n="Organization profile|Title of a section of the form">Contact information (General information)</legend>
 
         <div class="fieldset-container">
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !contact_general_name.valid }">
-            <label for="contact_general_name">Name</label>
+            <label for="contact_general_name" i18n="Organization profile|Label for the contact's name field (general information)">Name</label>
             <input type="text" id="contact_general_name" name="contact_general_name" ngModel #contact_general_name="ngModel" required />
-            <div *ngIf="f.submitted && contact_general_name.errors?.required" class="help-text">Name is required</div>
+            <div *ngIf="f.submitted && contact_general_name.errors?.required" class="help-text" i18n="Organization profile|Error message if the name of the contact isn't supplied (general information)">Name is required</div>
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !contact_general_email.valid }">
-            <label for="contact_general_email">Email</label>
+            <label for="contact_general_email" i18n="Organization profile|Label for the contact's email field (general information)">Email</label>
             <input type="email" id="contact_general_email" name="contact_general_email" ngModel #contact_general_email="ngModel" email required />
-            <div *ngIf="f.submitted && contact_general_email.errors?.required" class="help-text">Email is required</div>
-            <div *ngIf="f.submitted && contact_general_email.errors?.email && !contact_general_email.errors?.required" class="help-text">Please enter an email address</div>
+            <div *ngIf="f.submitted && contact_general_email.errors?.required" class="help-text" i18n="Organization profile|Error message if the contact email isn't supplied (general information)">Email is required</div>
+            <div *ngIf="f.submitted && contact_general_email.errors?.email && !contact_general_email.errors?.required" class="help-text" i18n="Organization profile|Error message if the contact email isn't valid (general information)">Please enter an email address</div>
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !contact_general_phone.valid }">
-            <label for="contact_general_phone">Phone number</label>
+            <label for="contact_general_phone" i18n="Organization profile|Label for the contact's phone number field (general information)">Phone number</label>
             <input type="tel" id="contact_general_phone" name="contact_general_phone" ngModel #contact_general_phone="ngModel" required />
-            <div *ngIf="f.submitted && contact_general_phone.errors?.required" class="help-text">Phone number is required</div>
+            <div *ngIf="f.submitted && contact_general_phone.errors?.required" class="help-text" i18n="Organization profile|Error message if the contact phone number isn't supplied (general information)">Phone number is required</div>
           </div>
 
         </div>
@@ -44,27 +44,27 @@
       </fieldset>
 
       <fieldset>
-        <legend>Contact information (For inquiries on data uploaded)</legend>
+        <legend i18n="Organization profile|Title of a section of the form">Contact information (For inquiries on data uploaded)</legend>
 
         <div class="fieldset-container">
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !contact_inquiries_name.valid }">
-            <label for="contact_inquiries_name">Name</label>
+            <label for="contact_inquiries_name" i18n="Organization profile|Label for the contact's name field (inquiries on data uploaded)">Name</label>
             <input type="text" id="contact_inquiries_name" name="contact_inquiries_name" ngModel #contact_inquiries_name="ngModel" required />
-            <div *ngIf="f.submitted && contact_inquiries_name.errors?.required" class="help-text">Name is required</div>
+            <div *ngIf="f.submitted && contact_inquiries_name.errors?.required" class="help-text" i18n="Organization profile|Error message if the name of the contact isn't supplied (inquiries on data uploaded)">Name is required</div>
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !contact_inquiries_email.valid }">
-            <label for="contact_inquiries_email">Email</label>
+            <label for="contact_inquiries_email" i18n="Organization profile|Label for the contact's email field (inquiries on data uploaded)">Email</label>
             <input type="email" id="contact_inquiries_email" name="contact_inquiries_email" ngModel #contact_inquiries_email="ngModel" email required />
-            <div *ngIf="f.submitted && contact_inquiries_email.errors?.required" class="help-text">Email is required</div>
-            <div *ngIf="f.submitted && contact_inquiries_email.errors?.email && !contact_inquiries_email.errors?.required" class="help-text">Please enter an email address</div>
+            <div *ngIf="f.submitted && contact_inquiries_email.errors?.required" class="help-text" i18n="Organization profile|Error message if the contact email isn't supplied (inquiries on data uploaded)">Email is required</div>
+            <div *ngIf="f.submitted && contact_inquiries_email.errors?.email && !contact_inquiries_email.errors?.required" class="help-text" i18n="Organization profile|Error message if the contact email isn't valid (inquiries on data uploaded)">Please enter an email address</div>
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !contact_inquiries_phone.valid }">
-            <label for="contact_inquiries_phone">Phone number</label>
+            <label for="contact_inquiries_phone" i18n="Organization profile|Label for the contact's phone number field (inquiries on data uploaded)">Phone number</label>
             <input type="tel" id="contact_inquiries_phone" name="contact_inquiries_phone" ngModel #contact_inquiries_phone="ngModel" required />
-            <div *ngIf="f.submitted && contact_inquiries_phone.errors?.required" class="help-text">Phone number is required</div>
+            <div *ngIf="f.submitted && contact_inquiries_phone.errors?.required" class="help-text" i18n="Organization profile|Error message if the contact phone number isn't supplied (inquiries on data uploaded)">Phone number is required</div>
           </div>
 
         </div>
@@ -72,82 +72,82 @@
       </fieldset>
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !type_organization.valid }">
-        <label for="type_organization">Type of organization</label>
+        <label for="type_organization" i18n="Organization profile|Label for the type of organization field">Type of organization</label>
         <select id="type_organization" name="type_organization" ngModel #type_organization="ngModel" required>
-          <option value="ngo">Non governmental organization (NGO)</option>
-          <option value="academic">Academic</option>
-          <option value="research_institute">Research Institute</option>
-          <option value="private_company">Private company</option>
-          <option value="other">Other</option>
+          <option value="ngo" i18n="Type of organization">Non governmental organization (NGO)</option>
+          <option value="academic" i18n="Type of organization">Academic</option>
+          <option value="research_institute" i18n="Type of organization">Research Institute</option>
+          <option value="private_company" i18n="Type of organization">Private company</option>
+          <option value="other" i18n="Type of organization">Other</option>
         </select>
-        <div *ngIf="f.submitted && type_organization.errors?.required" class="help-text">Please select a type of organization</div>
+        <div *ngIf="f.submitted && type_organization.errors?.required" class="help-text" i18n="Organization profile|Error message if the type of organization isn't supplied (the user will have to choose between some options)">Please select a type of organization</div>
       </div>
 
       <div class="form-group -inline" *ngIf="type_organization.value === 'other'" [ngClass]="{ 'has-error': f.submitted && !type_organization_other.valid }">
-        <label for="type_organization_other">Please specify:</label>
+        <label for="type_organization_other" i18n="Organization profile|Label of an additional field where the user is asked to specify/detail a previous field">Please specify:</label>
         <input type="text" id="type_organization_other" name="type_organization_other" ngModel #type_organization_other="ngModel" required />
-        <div *ngIf="f.submitted && type_organization_other.errors?.required" class="help-text">Type of organization is required</div>
+        <div *ngIf="f.submitted && type_organization_other.errors?.required" class="help-text" i18n="Organization profile|Error message if the 'more specific' type of organization field isn't supplied">Type of organization is required</div>
       </div>
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !type_monitoring_organization.valid }">
-        <label for="type_monitoring_organization">Type of monitoring organization</label>
+        <label for="type_monitoring_organization" i18n="Organization profile|Label for the type of monitoring organization field">Type of monitoring organization</label>
         <select id="type_monitoring_organization" name="type_monitoring_organization" ngModel #type_monitoring_organization="ngModel" required>
-          <option value="mandated">Mandated</option>
-          <option value="semi_mandated">Semi mandated</option>
-          <option value="non-mandated">Non-mandated (external)</option>
-          <option value="other">Other</option>
+          <option value="mandated" i18n="type of monitoring organization">Mandated</option>
+          <option value="semi_mandated" i18n="type of monitoring organization">Semi mandated</option>
+          <option value="non-mandated" i18n="type of monitoring organization">Non-mandated (external)</option>
+          <option value="other" i18n="type of monitoring organization">Other</option>
         </select>
-        <div *ngIf="f.submitted && type_monitoring_organization.errors?.required" class="help-text">Please select a type of monitoring organization</div>
+        <div *ngIf="f.submitted && type_monitoring_organization.errors?.required" class="help-text" i18n="Organization profile|Error message if the type of monitoring organization isn't supplied (the user will have to choose between some options)">Please select a type of monitoring organization</div>
       </div>
 
       <div class="form-group -inline" *ngIf="type_monitoring_organization.value === 'other'" [ngClass]="{ 'has-error': f.submitted && !type_monitoring_organization_other.valid }">
-        <label for="type_monitoring_organization_other">Please specify:</label>
+        <label for="type_monitoring_organization_other" i18n="Organization profile|Label of an additional field where the user is asked to specify/detail a previous field">Please specify:</label>
         <input type="text" id="type_monitoring_organization_other" name="type_monitoring_organization_other" ngModel #type_monitoring_organization_other="ngModel" required />
-        <div *ngIf="f.submitted && type_monitoring_organization_other.errors?.required" class="help-text">Type of monitoring organization is required</div>
+        <div *ngIf="f.submitted && type_monitoring_organization_other.errors?.required" class="help-text" i18n="Organization profile|Error message if the 'more specific' type of monitoring organization field isn't supplied">Type of monitoring organization is required</div>
       </div>
 
       <fieldset>
-        <legend>Current independent monitoring project</legend>
+        <legend i18n="Organization profile|Title of a section of the form">Current independent monitoring project</legend>
 
         <div class="fieldset-container">
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !project_title.valid }">
-            <label for="project_title">Project title</label>
+            <label for="project_title" i18n="Organization profile|Label for the project title field">Project title</label>
             <input type="text" id="project_title" name="project_title" ngModel #project_title="ngModel" required />
-            <div *ngIf="f.submitted && project_title.errors?.required" class="help-text">Project title is required</div>
+            <div *ngIf="f.submitted && project_title.errors?.required" class="help-text" i18n="Organization profile|Error message if the project title isn't supplied">Project title is required</div>
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !project_organization.valid }">
-            <label for="project_organization">Lead organization</label>
+            <label for="project_organization" i18n="Organization profile|Label for the lead organization field (of a project)">Lead organization</label>
             <input type="text" id="project_organization" name="project_organization" ngModel #project_organization="ngModel" required />
-            <div *ngIf="f.submitted && project_organization.errors?.required" class="help-text">Lead organization is required</div>
+            <div *ngIf="f.submitted && project_organization.errors?.required" class="help-text" i18n="Organization profile|Error message if the lead organization of a project isn't supplied">Lead organization is required</div>
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !project_start_date.valid }">
-            <label for="project_start_date">Start date</label>
+            <label for="project_start_date" i18n="Organization profile|Label for the start date field (of a project)">Start date</label>
             <otp-datepicker [id]="'project_start_date'" [name]="'project_start_date'" ngModel #project_start_date="ngModel" required></otp-datepicker>
-            <div *ngIf="f.submitted && project_start_date.errors?.required" class="help-text">Start date is required</div>
+            <div *ngIf="f.submitted && project_start_date.errors?.required" class="help-text" i18n="Organization profile|Error message if the start date of a project isn't supplied">Start date is required</div>
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !project_duration.valid }">
-            <label for="project_duration">Project duration (years)</label>
+            <label for="project_duration" i18n="Organization profile|Label for the duration in years field (of a project)">Project duration (years)</label>
             <input type="number" id="project_duration" name="project_duration" ngModel #project_duration="ngModel" required />
-            <div *ngIf="f.submitted && project_duration.errors?.required" class="help-text">Project duration is required</div>
+            <div *ngIf="f.submitted && project_duration.errors?.required" class="help-text" i18n="Organization profile|Error message if the duration in years of a project isn't supplied">Project duration is required</div>
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !project_donors.valid }">
-            <label for="project_donors">Donor(s)</label>
+            <label for="project_donors" i18n="Organization profile|Label for the donor(s) field (of a project)">Donor(s)</label>
             <input type="text" id="project_donors" name="project_donors" ngModel #project_donors="ngModel" required />
-            <div *ngIf="f.submitted && project_donors.errors?.required" class="help-text">Donor(s) is required</div>
+            <div *ngIf="f.submitted && project_donors.errors?.required" class="help-text" i18n="Organization profile|Error message if the donor(s) isn't supplied">Donor(s) is required</div>
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !project_website.valid }">
-            <label for="project_website">Project website</label>
+            <label for="project_website" i18n="Organization profile|Label for the website URL field (of a project)">Project website</label>
             <input type="url" id="project_website" name="project_website" ngModel #project_website="ngModel" />
           </div>
 
           <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !project_additional_info.valid }">
-            <label for="project_additional_info">Additional information on status, progress, etc.</label>
+            <label for="project_additional_info" i18n="Organization profile|Label for the additional information field (of a project)">Additional information on status, progress, etc.</label>
             <input type="text" id="project_additional_info" name="project_additional_info" ngModel #project_additional_info="ngModel" />
           </div>
 
@@ -158,28 +158,28 @@
       <ng-template [ngIf]="showMore">
 
         <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !website_link.valid }">
-          <label for="website_link">Website link</label>
+          <label for="website_link" i18n="Organization profile|Label for the website URL field (of the organization)">Website link</label>
           <input type="url" id="website_link" name="website_link" ngModel #website_link="ngModel" />
         </div>
 
         <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !mission.valid }">
-          <label for="mission">Organisation’s mission (max 250 characters)</label>
+          <label for="mission" i18n="Organization profile|Label for the organization's mission field (with a limit of 250 chars)">Organisation’s mission (max 250 characters)</label>
           <textarea id="mission" name="mission" ngModel #mission="ngModel" maxlength="250"></textarea>
-          <div *ngIf="f.submitted && mission.errors?.maxlength" class="help-text">You exceed the maximum number of characters</div>
+          <div *ngIf="f.submitted && mission.errors?.maxlength" class="help-text" i18n="Organization profile|Error message if the organization's mission exceeds 250 chars">You exceed the maximum number of characters</div>
         </div>
 
         <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !quality_control.valid }">
-          <label for="quality_control">Quality control (max 500 characters)</label>
+          <label for="quality_control" i18n="Organization profile|Label for the quality control process field (with a limit of 500 chars)">Quality control (max 500 characters)</label>
           <textarea id="quality_control" name="quality_control" ngModel #quality_control="ngModel" maxlength="500"></textarea>
-          <div *ngIf="f.submitted && quality_control.errors?.maxlength" class="help-text">You exceed the maximum number of characters</div>
+          <div *ngIf="f.submitted && quality_control.errors?.maxlength" class="help-text" i18n="Organization profile|Error message if the quality control process field exceeds 500 chars">You exceed the maximum number of characters</div>
         </div>
 
         <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !geographical_scope.valid }">
-          <label for="geographical_scope">Geographical scope of work</label>
+          <label for="geographical_scope" i18n="Organization profile|Label for the organization's geographical scope field">Geographical scope of work</label>
           <select id="geographical_scope" name="geographical_scope" ngModel #geographical_scope="ngModel">
-            <option value="sub-national">Sub-national</option>
-            <option value="national">National</option>
-            <option value="international">International</option>
+            <option value="sub-national" i18n="Geographical scope of an organization">Sub-national</option>
+            <option value="national" i18n="Geographical scope of an organization">National</option>
+            <option value="international" i18n="Geographical scope of an organization">International</option>
           </select>
         </div>
 
@@ -191,42 +191,42 @@
 
             <fieldset>
 
-              <legend>Project 1</legend>
+              <legend i18n="Organization profile|Title of a section of the form">Project 1</legend>
 
               <div class="fieldset-container">
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_1_title.valid }">
-                  <label for="past_project_1_title">Project title</label>
+                  <label for="past_project_1_title" i18n="Organization profile|Label for the project title field">Project title</label>
                   <input type="text" id="past_project_1_title" name="past_project_1_title" ngModel #past_project_1_title="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_1_organization.valid }">
-                  <label for="past_project_1_organization">Lead organization</label>
+                  <label for="past_project_1_organization" i18n="Organization profile|Label for the lead organization field (of a project)">Lead organization</label>
                   <input type="text" id="past_project_1_organization" name="past_project_1_organization" ngModel #past_project_1_organization="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_1_start_date.valid }">
-                  <label for="past_project_1_start_date">Start date</label>
+                  <label for="past_project_1_start_date" i18n="Organization profile|Label for the start date field (of a project)">Start date</label>
                   <otp-datepicker [id]="'past_project_1_start_date'" [name]="'past_project_1_start_date'" ngModel #past_project_1_start_date="ngModel"></otp-datepicker>
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_1_duration.valid }">
-                  <label for="past_project_1_duration">Project duration (years)</label>
+                  <label for="past_project_1_duration" i18n="Organization profile|Label for the duration in years field (of a project)">Project duration (years)</label>
                   <input type="number" id="past_project_1_duration" name="past_project_1_duration" ngModel #past_project_1_duration="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_1_donors.valid }">
-                  <label for="past_project_1_donors">Donor(s)</label>
+                  <label for="past_project_1_donors" i18n="Organization profile|Label for the donor(s) field (of a project)">Donor(s)</label>
                   <input type="text" id="past_project_1_donors" name="past_project_1_donors" ngModel #past_project_1_donors="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_1_website.valid }">
-                  <label for="past_project_1_website">Project website</label>
+                  <label for="past_project_1_website" i18n="Organization profile|Label for the website URL field (of a project)">Project website</label>
                   <input type="url" id="past_project_1_website" name="past_project_1_website" ngModel #past_project_1_website="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_1_additional_info.valid }">
-                  <label for="past_project_1_additional_info">Additional information on status, progress, etc.</label>
+                  <label for="past_project_1_additional_info" i18n="Organization profile|Label for the additional information field (of a project)">Additional information on status, progress, etc.</label>
                   <input type="text" id="past_project_1_additional_info" name="past_project_1_additional_info" ngModel #past_project_1_additional_info="ngModel" />
                 </div>
 
@@ -236,42 +236,42 @@
 
             <fieldset>
 
-              <legend>Project 2</legend>
+              <legend i18n="Organization profile|Title of a section of the form">Project 2</legend>
 
               <div class="fieldset-container">
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_2_title.valid }">
-                  <label for="past_project_2_title">Project title</label>
+                  <label for="past_project_2_title" i18n="Organization profile|Label for the project title field">Project title</label>
                   <input type="text" id="past_project_2_title" name="past_project_2_title" ngModel #past_project_2_title="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_2_organization.valid }">
-                  <label for="past_project_2_organization">Lead organization</label>
+                  <label for="past_project_2_organization" i18n="Organization profile|Label for the lead organization field (of a project)">Lead organization</label>
                   <input type="text" id="past_project_2_organization" name="past_project_2_organization" ngModel #past_project_2_organization="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_2_start_date.valid }">
-                  <label for="past_project_2_start_date">Start date</label>
+                  <label for="past_project_2_start_date" i18n="Organization profile|Label for the start date field (of a project)">Start date</label>
                   <otp-datepicker [id]="'past_project_2_start_date'" [name]="'past_project_2_start_date'" ngModel #past_project_2_start_date="ngModel"></otp-datepicker>
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_2_duration.valid }">
-                  <label for="past_project_2_duration">Project duration (years)</label>
+                  <label for="past_project_2_duration" i18n="Organization profile|Label for the duration in years field (of a project)">Project duration (years)</label>
                   <input type="number" id="past_project_2_duration" name="past_project_2_duration" ngModel #past_project_2_duration="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_2_donors.valid }">
-                  <label for="past_project_2_donors">Donor(s)</label>
+                  <label for="past_project_2_donors" i18n="Organization profile|Label for the donor(s) field (of a project)">Donor(s)</label>
                   <input type="text" id="past_project_2_donors" name="past_project_2_donors" ngModel #past_project_2_donors="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_2_website.valid }">
-                  <label for="past_project_2_website">Project website</label>
+                  <label for="past_project_2_website" i18n="Organization profile|Label for the website URL field (of a project)">Project website</label>
                   <input type="url" id="past_project_2_website" name="past_project_2_website" ngModel #past_project_2_website="ngModel" />
                 </div>
 
                 <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !past_project_2_additional_info.valid }">
-                  <label for="past_project_2_additional_info">Additional information on status, progress, etc.</label>
+                  <label for="past_project_2_additional_info" i18n="Organization profile|Label for the additional information field (of a project)">Additional information on status, progress, etc.</label>
                   <input type="text" id="past_project_2_additional_info" name="past_project_2_additional_info" ngModel #past_project_2_additional_info="ngModel" />
                 </div>
 
@@ -287,7 +287,10 @@
 
       <div class="c-container -j-center -t-a-start">
         <div class="c-button-container -j-center">
-          <button type="button" (click)="showMore = !showMore" class="c-button -secondary">{{showMore ? 'Less' : 'More'}} details</button>
+          <button type="button" (click)="showMore = !showMore" class="c-button -secondary">
+            <ng-template [ngIf]="showMore" i18n="Less details button">Less details</ng-template>
+            <ng-template [ngIf]="!showMore" i18n="More details button">More details</ng-template>
+          </button>
         </div>
       </div>
 
@@ -297,8 +300,8 @@
 
       <div class="c-container -j-end -t-d-column -t-a-start">
         <div class="c-button-container -xs-j-between -t-j-end">
-          <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Discard changes</button>
-          <button disable="loading" type="submit" class="c-button -primary">Save changes</button>
+          <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Discard change button">Discard changes</button>
+          <button disable="loading" type="submit" class="c-button -primary" i18n="Save changes button">Save changes</button>
         </div>
       </div>
 

--- a/src/app/pages/my-otp/profile/organization-profile.component.scss
+++ b/src/app/pages/my-otp/profile/organization-profile.component.scss
@@ -1,4 +1,4 @@
-@import 'src/settings';
+@import 'src/settings.scss';
 
 :host {
   display: block;

--- a/src/app/pages/observations/observation-detail-edit.component.html
+++ b/src/app/pages/observations/observation-detail-edit.component.html
@@ -1,136 +1,136 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value, $event)" #f="ngForm" novalidate>
   <div class="c-container -j-between -t-d-column -t-a-start">
-    <h2>{{titleText}}</h2>
+    <h2 i18n="Observation edition|Title of the page">Update observation</h2>
     <div class="c-button-container -j-end form-group" *otpMinTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Update</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Update button">Update</button>
     </div>
   </div>
 
   <div class="form-header">
     <div class="form-group">
-      <label for="observation_type">Type</label>
+      <label for="observation_type" i18n="Observation creation/edition|Label for the type field">Type</label>
       <select disabled id="observation_type" name="observation_type"
         [(ngModel)]="observation && observation.observation_type" #observation_type="ngModel">
-          <option selected value="AnnexOperator">Operator</option>
-          <option value="AnnexGovernance">Governance</option>
+          <option selected value="AnnexOperator" i18n="Observation type">Operator</option>
+          <option value="AnnexGovernance" i18n="Observation type">Governance</option>
       </select>
     </div>
   </div>
 
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !country_id.valid }">
-      <label for="country_id">Country</label>
+      <label for="country_id" i18n="Observation creation/edition|Label for the country field">Country</label>
       <select id="country_id" (change)="onCountryChange(country_id.value)" name="country_id"
         [(ngModel)]="observation && observation.country.id" #country_id="ngModel" required>
         <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
       </select>
-      <div *ngIf="f.submitted && !country_id.valid" class="help-text">Please select a country</div>
+      <div *ngIf="f.submitted && !country_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the country isn't supplied (the user will have to user between some options)">Please select a country</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !latitude.valid }">
-      <label for="latitude">Latitude</label>
+      <label for="latitude" i18n="Observation creation/edition|Label for the latitude field">Latitude</label>
       <input id="latitude" type="text" class="form-control" name="latitude" [(ngModel)]="observation && observation.lat"
         #latitude="ngModel" required number/>
-      <div *ngIf="f.submitted && latitude.errors?.required" class="help-text">Latitude is required</div>
-      <div *ngIf="f.submitted && latitude.errors?.number && !latitude.errors?.required" class="help-text">Please enter a valid number</div>
+      <div *ngIf="f.submitted && latitude.errors?.required" class="help-text" i18n="Observation creation/edition|Error message if the latitude isn't supplied">Latitude is required</div>
+      <div *ngIf="f.submitted && latitude.errors?.number && !latitude.errors?.required" class="help-text" i18n="Observation creation/edition|Error message if the latitude isn't valid">Please enter a valid number</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !longitude.valid }">
-      <label for="longitude">Longitude</label>
+      <label for="longitude" i18n="Observation creation/edition|Label for the longitude field">Longitude</label>
       <input id="longitude" type="text" class="form-control" name="longitude" [(ngModel)]="observation && observation.lng"
         #longitude="ngModel" required number/>
-      <div *ngIf="f.submitted && longitude.errors?.required" class="help-text">Longitude is required</div>
-      <div *ngIf="f.submitted && longitude.errors?.number && !longitude.errors?.required" class="help-text">Please enter a valid number</div>
+      <div *ngIf="f.submitted && longitude.errors?.required" class="help-text" i18n="Observation creation/edition|Error message if the longitude isn't supplied">Longitude is required</div>
+      <div *ngIf="f.submitted && longitude.errors?.number && !longitude.errors?.required" class="help-text" i18n="Observation creation/edition|Error message if the longitude isn't valid">Please enter a valid number</div>
     </div>
 
     <div *ngIf="isGovernance" class="form-group" [ngClass]="{ 'has-error': f.submitted && !annex_governance_id.valid }">
-      <label for="annex_governance_id">Sub-category</label>
+      <label for="annex_governance_id" i18n="Observation creation/edition|Label for the sub-category field">Sub-category</label>
       <select id="annex_governance_id" (change)="onAnnexGovernanceChange(annex_governance_id.value)" name="annex_governance_id"
         [(ngModel)]="observation && observation.annex_governance.id" #annex_governance_id="ngModel" required>
         <option *ngFor="let annexGovernance of annexGovernances" [value]="annexGovernance.id">{{ annexGovernance.governance_problem }}</option>
       </select>
-      <div *ngIf="f.submitted && !annex_governance_id.valid" class="help-text">Please select a sub-category</div>
+      <div *ngIf="f.submitted && !annex_governance_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the sub-category isn't supplied (the user will have to user between some options)">Please select a sub-category</div>
     </div>
 
     <div *ngIf="!isGovernance" class="form-group" [ngClass]="{ 'has-error': f.submitted && !annex_operator_id.valid }">
-      <label for="annex_operator_id">Sub-category</label>
+      <label for="annex_operator_id" i18n="Observation creation/edition|Label for the country field">Sub-category</label>
       <select id="annex_operator_id" (change)="onAnnexOperatorChange(annex_operator_id.value)" name="annex_operator_id"
         [(ngModel)]="observation && observation.annex_operator.id" #annex_operator_id="ngModel" required>
         <option *ngFor="let annexOperator of annexOperators" [value]="annexOperator.id">{{ annexOperator.illegality }}</option>
       </select>
-      <div *ngIf="f.submitted && !annex_operator_id.valid" class="help-text">Please select a sub-category</div>
+      <div *ngIf="f.submitted && !annex_operator_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the sub-category isn't supplied (the user will have to user between some options)">Please select a sub-category</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !severity_id.valid }">
-      <label for="severity_id">Severity</label>
+      <label for="severity_id" i18n="Observation creation/edition|Label for the severity field">Severity</label>
       <select id="severity_id" name="severity_id" [(ngModel)]="observation && observation.severity && observation.severity.id"
         #severity_id="ngModel" required>
         <option *ngFor="let severity of severities" [value]="severity.id">{{ severity.level }} - {{ severity.details }}</option>
       </select>
-      <div *ngIf="f.submitted && !severity_id.valid" class="help-text">Please select a severity</div>
+      <div *ngIf="f.submitted && !severity_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the severity isn't supplied (the user will have to user between some options)">Please select a severity</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !publication_date.valid }">
-      <label for="publication_date">Publication date</label>
+      <label for="publication_date" i18n="Observation creation/edition|Label for the publication date field">Publication date</label>
       <otp-datepicker [id]="'publication_date'" [name]="'publication_date'" [(ngModel)]="observation && observation.publication_date" #publication_date="ngModel" required></otp-datepicker>
-      <div *ngIf="f.submitted && !publication_date.valid" class="help-text">Publication date is required</div>
+      <div *ngIf="f.submitted && !publication_date.valid" class="help-text" i18n="Observation creation/edition|Error message if the publication date isn't supplied">Publication date is required</div>
     </div>
 
     <div *ngIf="isGovernance" class="form-group" [ngClass]="{ 'has-error': f.submitted && !government_id.valid }">
-      <label for="government_id">Government Entity</label>
+      <label for="government_id" i18n="Observation creation/edition|Label for the government entity field">Government Entity</label>
       <select id="government_id" name="government_id" [(ngModel)]="observation && observation.government && observation.government.id" #government_id="ngModel" required>
         <option *ngFor="let government of governments" [value]="government.id">{{ government.government_entity }}</option>
       </select>
-      <div *ngIf="f.submitted && !government_id.valid" class="help-text">Please select a government entity</div>
+      <div *ngIf="f.submitted && !government_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the government entity isn't supplied (the user will have to user between some options)">Please select a government entity</div>
     </div>
 
     <div *ngIf="!isGovernance" class="form-group">
-      <label for="pv">PV</label>
+      <label for="pv" i18n="Observation creation/edition|Label for the PV field">PV</label>
       <input id="pv" type="text" class="form-control" name="pv" [(ngModel)]="observation && observation.pv" #pv="ngModel"  />
     </div>
 
     <div *ngIf="!isGovernance" class="form-group">
-      <label for="concern_opinion">Opinion of operator</label>
+      <label for="concern_opinion" i18n="Observation creation/edition|Label for the opinion of operator field">Opinion of operator</label>
       <input id="concern_opinion" type="text" class="form-control" name="concern_opinion"
         [(ngModel)]="observation && observation.concern_opinion" #concern_opinion="ngModel"  />
     </div>
 
     <div *ngIf="!isGovernance" class="form-group">
-      <label for="litigation_status">Litigation status</label>
+      <label for="litigation_status" i18n="Observation creation/edition|Label for the litigation status field">Litigation status</label>
       <input id="litigation_status" type="text" class="form-control" name="litigation_status"
         [(ngModel)]="observation && observation.litigation_status" #litigation_status="ngModel"  />
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !observer_id.valid }">
-      <label for="observer_id">Monitor</label>
+      <label for="observer_id" i18n="Observation creation/edition|Label for the monitor field">Monitor</label>
       <select id="observer_id" name="observer_id" [(ngModel)]="observation && observation.observer.id" #observer_id="ngModel" required>
         <option *ngFor="let observer of observers" [value]="observer.id">{{ observer.name }}</option>
       </select>
-      <div *ngIf="f.submitted && !observer_id.valid" class="help-text">Please select an observer</div>
+      <div *ngIf="f.submitted && !observer_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the monitor isn't supplied (the user will have to user between some options)">Please select a monitor</div>
     </div>
 
     <div *ngIf="!isGovernance" class="form-group" [ngClass]="{ 'has-error': f.submitted && !operator_id.valid }">
-      <label for="operator_id">Operator</label>
+      <label for="operator_id" i18n="Observation creation/edition|Label for the operator field">Operator</label>
       <select id="operator_id" name="operator_id" [(ngModel)]="observation && observation.operator && observation.operator.id" #operator_id="ngModel" required>
         <option *ngFor="let operator of operators" [value]="operator.id">{{ operator.name }}</option>
       </select>
-      <div *ngIf="f.submitted && !operator_id.valid" class="help-text">Please select an operator</div>
+      <div *ngIf="f.submitted && !operator_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the operator isn't supplied (the user will have to user between some options)">Please select an operator</div>
     </div>
 
     <div class="form-group">
-      <label for="is_active">Active</label>
+      <label for="is_active" i18n="Observation creation/edition|Label for the active field">Active</label>
       <input id="is_active" type="checkbox" name="is_active" [(ngModel)]="observation && observation.is_active" #is_active="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="details">Details</label>
+      <label for="details" i18n="Observation creation/edition|Label for the details field">Details</label>
       <textarea id="details" name="details" [(ngModel)]="observation && observation.details" #details="ngModel"></textarea>
     </div>
 
     <div class="form-group">
-      <label for="evidence">Evidence</label>
+      <label for="evidence" i18n="Observation creation/edition|Label for the evidence field">Evidence</label>
       <input id="evidence" type="text" class="form-control" name="evidence" [(ngModel)]="observation && observation.evidence" #evidence="ngModel"  />
     </div>
   </div>
@@ -138,13 +138,13 @@
 
   <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
     <div class="c-button-container -j-end form-group">
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Update</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Update button">Update</button>
     </div>
   </div>
 
   <otp-action-bar *otpMaxTablet>
-    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-    <button disable="loading" type="submit" class="c-button -primary">Update</button>
+    <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+    <button disable="loading" type="submit" class="c-button -primary" i18n="Update button">Update</button>
   </otp-action-bar>
 </form>

--- a/src/app/pages/observations/observation-detail-edit.component.ts
+++ b/src/app/pages/observations/observation-detail-edit.component.ts
@@ -24,7 +24,6 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ObservationDetailEditComponent implements OnInit {
 
-  titleText: String = 'Edit observation';
   observation: Observation;
   loading = false;
   countries: Country[];

--- a/src/app/pages/observations/observation-detail.component.html
+++ b/src/app/pages/observations/observation-detail.component.html
@@ -1,130 +1,130 @@
 <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
 <form name="form" class="c-form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
   <div class="c-container -j-between -t-d-column -t-a-start">
-    <h2>{{titleText}}</h2>
+    <h2 i18n="Observation creation|Title of the page">New observation</h2>
     <div class="c-button-container -j-end form-group" *otpMinTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </div>
   </div>
 
   <div class="form-header">
     <div class="form-group">
-      <label for="observation_type">Type</label>
+      <label for="observation_type" i18n="Observation creation/edition|Label for the type field">Type</label>
       <select id="observation_type" (change)="onTypeChange($event)" name="observation_type" ngModel #observation_type="ngModel" required>
-          <option selected value="AnnexOperator">Operator</option>
-          <option value="AnnexGovernance">Governance</option>
+          <option selected value="AnnexOperator" i18n="Observation type">Operator</option>
+          <option value="AnnexGovernance" i18n="Observation type">Governance</option>
       </select>
-      <div *ngIf="f.submitted && !observation_type.valid" class="help-text">Please select a observation type</div>
+      <div *ngIf="f.submitted && !observation_type.valid" class="help-text" i18n="Observation creation/edition|Error message if the type isn't supplied (the user will have to user between some options)">Please select a observation type</div>
     </div>
   </div>
 
   <div class="form-container">
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !country_id.valid }">
-      <label for="country_id">Country</label>
+      <label for="country_id" i18n="Observation creation/edition|Label for the country field">Country</label>
       <select id="country_id" (change)="onCountryChange(country_id.value)" name="country_id" ngModel #country_id="ngModel" required>
         <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
       </select>
-      <div *ngIf="f.submitted && !country_id.valid" class="help-text">Please select a country</div>
+      <div *ngIf="f.submitted && !country_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the country isn't supplied (the user will have to user between some options)">Please select a country</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !latitude.valid }">
-        <label for="latitude">Latitude</label>
+        <label for="latitude" i18n="Observation creation/edition|Label for the latitude field">Latitude</label>
         <input id="latitude" type="text" class="form-control" name="latitude" ngModel #latitude="ngModel" required number/>
-        <div *ngIf="f.submitted && latitude.errors?.required" class="help-text">Latitude is required</div>
-        <div *ngIf="f.submitted && latitude.errors?.number && !latitude.errors?.required" class="help-text">Please enter a valid number</div>
+        <div *ngIf="f.submitted && latitude.errors?.required" class="help-text" i18n="Observation creation/edition|Error message if the latitude isn't supplied">Latitude is required</div>
+        <div *ngIf="f.submitted && latitude.errors?.number && !latitude.errors?.required" class="help-text" i18n="Observation creation/edition|Error message if the latitude isn't valid">Please enter a valid number</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !longitude.valid }">
-      <label for="longitude">Longitude</label>
+      <label for="longitude" i18n="Observation creation/edition|Label for the longitude field">Longitude</label>
       <input id="longitude" type="text" class="form-control" name="longitude" ngModel #longitude="ngModel" required number/>
-      <div *ngIf="f.submitted && longitude.errors?.required" class="help-text">Longitude is required</div>
-      <div *ngIf="f.submitted && longitude.errors?.number && !longitude.errors?.required" class="help-text">Please enter a valid number</div>
+      <div *ngIf="f.submitted && longitude.errors?.required" class="help-text" i18n="Observation creation/edition|Error message if the longitude isn't supplied">Longitude is required</div>
+      <div *ngIf="f.submitted && longitude.errors?.number && !longitude.errors?.required" class="help-text" i18n="Observation creation/edition|Error message if the longitude isn't valid">Please enter a valid number</div>
     </div>
 
     <div *ngIf="governanceSelected" class="form-group" [ngClass]="{ 'has-error': f.submitted && !annex_governance_id.valid }">
-      <label for="annex_governance_id">Sub-category</label>
+      <label for="annex_governance_id" i18n="Observation creation/edition|Label for the sub-category field">Sub-category</label>
       <select id="annex_governance_id" (change)="onSubCategoryChange(annex_governance_id.value)" name="annex_governance_id"
         [(ngModel)]="observation && observation.annex_governance.id" #annex_governance_id="ngModel" required>
         <option *ngFor="let annexGovernance of annexGovernances" [value]="annexGovernance.id">{{ annexGovernance.governance_problem }}</option>
       </select>
-      <div *ngIf="f.submitted && !annex_governance_id.valid" class="help-text">Please select a sub-category</div>
+      <div *ngIf="f.submitted && !annex_governance_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the sub-category isn't supplied (the user will have to user between some options)">Please select a sub-category</div>
     </div>
 
     <div *ngIf="!governanceSelected" class="form-group" [ngClass]="{ 'has-error': f.submitted && !annex_operator_id.valid }">
-      <label for="annex_operator_id">Sub-category</label>
+      <label for="annex_operator_id" i18n="Observation creation/edition|Label for the country field">Sub-category</label>
       <select id="annex_operator_id" (change)="onSubCategoryChange(annex_operator_id.value)" name="annex_operator_id"
         [(ngModel)]="observation && observation.annex_operator.id" #annex_operator_id="ngModel" required>
         <option *ngFor="let annexOperator of annexOperators" [value]="annexOperator.id">{{ annexOperator.illegality }}</option>
       </select>
-      <div *ngIf="f.submitted && !annex_operator_id.valid" class="help-text">Please select a sub-category</div>
+      <div *ngIf="f.submitted && !annex_operator_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the sub-category isn't supplied (the user will have to user between some options)">Please select a sub-category</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !severity_id.valid }">
-      <label for="severity_id">Severity</label>
+      <label for="severity_id" i18n="Observation creation/edition|Label for the severity field">Severity</label>
       <select id="severity_id" name="severity_id" ngModel #severity_id="ngModel" required>
         <option *ngFor="let severity of severities" [value]="severity.id">{{ severity.level }} - {{ severity.details }}</option>
       </select>
-      <div *ngIf="f.submitted && !severity_id.valid" class="help-text">Please select a severity</div>
+      <div *ngIf="f.submitted && !severity_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the severity isn't supplied (the user will have to user between some options)">Please select a severity</div>
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !publication_date.valid }">
-      <label for="publication_date">Publication date</label>
+      <label for="publication_date" i18n="Observation creation/edition|Label for the publication date field">Publication date</label>
       <otp-datepicker [id]="'publication_date'" [name]="'publication_date'" ngModel #publication_date="ngModel" required></otp-datepicker>
-      <div *ngIf="f.submitted && !publication_date.valid" class="help-text">Publication date is required</div>
+      <div *ngIf="f.submitted && !publication_date.valid" class="help-text" i18n="Observation creation/edition|Error message if the publication date isn't supplied">Publication date is required</div>
     </div>
 
     <div *ngIf="governanceSelected" class="form-group" [ngClass]="{ 'has-error': f.submitted && !government_id.valid }">
-      <label for="government_id">Government Entity</label>
+      <label for="government_id" i18n="Observation creation/edition|Label for the government entity field">Government Entity</label>
       <select id="government_id" name="government_id" ngModel #government_id="ngModel" required>
         <option *ngFor="let government of governments" [value]="government.id">{{ government.government_entity }}</option>
       </select>
-      <div *ngIf="f.submitted && !government_id.valid" class="help-text">Please select a government entity</div>
+      <div *ngIf="f.submitted && !government_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the government entity isn't supplied (the user will have to user between some options)">Please select a government entity</div>
     </div>
 
     <div *ngIf="!governanceSelected" class="form-group">
-      <label for="pv">PV</label>
+      <label for="pv" i18n="Observation creation/edition|Label for the PV field">PV</label>
       <input id="pv" type="text" class="form-control" name="pv" ngModel #pv="ngModel"  />
     </div>
 
     <div *ngIf="!governanceSelected" class="form-group">
-      <label for="concern_opinion">Opinion of operator</label>
+      <label for="concern_opinion" i18n="Observation creation/edition|Label for the opinion of operator field">Opinion of operator</label>
       <input id="concern_opinion" type="text" class="form-control" name="concern_opinion" ngModel #concern_opinion="ngModel"  />
     </div>
 
     <div *ngIf="!governanceSelected" class="form-group">
-      <label for="litigation_status">Litigation status</label>
+      <label for="litigation_status" i18n="Observation creation/edition|Label for the litigation status field">Litigation status</label>
       <input id="litigation_status" type="text" class="form-control" name="litigation_status" ngModel #litigation_status="ngModel"  />
     </div>
 
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !observer_id.valid }">
-      <label for="observer_id">Monitor</label>
+      <label for="observer_id" i18n="Observation creation/edition|Label for the monitor field">Monitor</label>
       <select id="observer_id" name="observer_id" ngModel #observer_id="ngModel" required>
         <option *ngFor="let observer of observers" [value]="observer.id">{{ observer.name }}</option>
       </select>
-      <div *ngIf="f.submitted && !observer_id.valid" class="help-text">Please select an observer</div>
+      <div *ngIf="f.submitted && !observer_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the monitor isn't supplied (the user will have to user between some options)">Please select a monitor</div>
     </div>
 
     <div *ngIf="!governanceSelected" class="form-group" [ngClass]="{ 'has-error': f.submitted && !operator_id.valid }">
-      <label for="operator_id">Operator</label>
+      <label for="operator_id" i18n="Observation creation/edition|Label for the operator field">Operator</label>
       <select id="operator_id" name="operator_id" ngModel #operator_id="ngModel" required>
         <option *ngFor="let operator of operators" [value]="operator.id">{{ operator.name }}</option>
       </select>
-      <div *ngIf="f.submitted && !operator_id.valid" class="help-text">Please select an operator</div>
+      <div *ngIf="f.submitted && !operator_id.valid" class="help-text" i18n="Observation creation/edition|Error message if the operator isn't supplied (the user will have to user between some options)">Please select an operator</div>
     </div>
 
     <div class="form-group">
-      <label for="active">Active</label>
+      <label for="active" i18n="Observation creation/edition|Label for the active field">Active</label>
       <input id="active" type="checkbox" name="active" ngModel #active="ngModel" />
     </div>
 
     <div class="form-group">
-      <label for="details">Details</label>
+      <label for="details" i18n="Observation creation/edition|Label for the details field">Details</label>
       <textarea id="details" name="details" ngModel #details="ngModel"></textarea>
     </div>
 
     <div class="form-group">
-      <label for="evidence">Evidence</label>
+      <label for="evidence" i18n="Observation creation/edition|Label for the evidence field">Evidence</label>
       <input id="evidence" type="text" class="form-control" name="evidence" ngModel #evidence="ngModel"  />
     </div>
   </div>
@@ -132,14 +132,14 @@
   <div class="form-footer">
     <div class="c-container -j-end -t-d-column -t-a-start" *otpMinTablet>
       <div class="c-button-container -j-end form-group">
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">Create</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
       </div>
     </div>
 
     <otp-action-bar *otpMaxTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">Create</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Create button">Create</button>
     </otp-action-bar>
   </div>
 

--- a/src/app/pages/observations/observation-detail.component.ts
+++ b/src/app/pages/observations/observation-detail.component.ts
@@ -22,8 +22,6 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./observation-detail.component.scss']
 })
 export class ObservationDetailComponent implements OnInit {
-
-  titleText: String = 'New observation';
   private model: any = {};
   loading = false;
   private returnUrl: string;

--- a/src/app/pages/observations/observation-list.component.html
+++ b/src/app/pages/observations/observation-list.component.html
@@ -6,20 +6,20 @@
     ></otp-navigation>
   </div>
   <div class="c-button-container -j-end">
-    <a class="c-button -primary" routerLink="../new">New observation</a>
+    <a class="c-button -primary" routerLink="../new" i18n="Button to create a new observation">New observation</a>
   </div>
 </div>
 
-<otp-table caption="Observations">
-  <otp-table-column name="Date" prop="publication_date">
+<otp-table i18n-caption="Caption for the table which lists the observations" caption="Observations">
+  <otp-table-column i18n-name="Table of observations|Name of the column corresponding to the date of the observations" name="Date" prop="publication_date">
     <ng-template let-value="value" table-cell-template>{{getFormatedDate(value)}}</ng-template>
   </otp-table-column>
-  <otp-table-column name="Country" prop="country.iso"></otp-table-column>
-  <otp-table-column name="Operator" prop="operator.name"></otp-table-column>
-  <otp-table-column name="Category" [prop]="this.observationType === 'operators' ? 'annex_operator.illegality' : 'annex_governance.governance_pillar'"></otp-table-column>
-  <otp-table-column name="Observation" prop="details"></otp-table-column>
-  <otp-table-column name="Severity" prop="severity.level"></otp-table-column>
-  <otp-table-column name="Actions">
+  <otp-table-column i18n-name="Table of observations|Name of the column corresponding to the country of the observations" name="Country" prop="country.iso"></otp-table-column>
+  <otp-table-column i18n-name="Table of observations|Name of the column corresponding to the operator name of the observations" name="Operator" prop="operator.name"></otp-table-column>
+  <otp-table-column i18n-name="Table of observations|Name of the column corresponding to the category of the observations" name="Category" [prop]="this.observationType === 'operators' ? 'annex_operator.illegality' : 'annex_governance.governance_pillar'"></otp-table-column>
+  <otp-table-column i18n-name="Table of observations|Name of the column corresponding to the details of the observations" name="Observation" prop="details"></otp-table-column>
+  <otp-table-column i18n-name="Table of observations|Name of the column corresponding to the severity of the observations" name="Severity" prop="severity.level"></otp-table-column>
+  <otp-table-column i18n-name="Table of observations|Name of the actions columns (containing the edit and delete button)" name="Actions">
     <ng-template let-row="row" table-cell-template>
       <ng-template [ngIf]="canEdit(row)">
         <button class="action" (click)="onEdit(row)" aria-label="Edit"><otp-icon name="#icon-edit"></otp-icon></button>

--- a/src/app/pages/observations/observation-list.component.html
+++ b/src/app/pages/observations/observation-list.component.html
@@ -1,9 +1,9 @@
 <div class="c-container -j-between -t-d-column -t-a-start">
   <div class="c-container -j-start -t-d-column -t-a-start">
-    <otp-navigation
-      layout="mini"
-      [items]="navigationItems"
-    ></otp-navigation>
+    <otp-navigation layout="mini">
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations' list page" name="Operators" url="../operators"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Menu located on the 'Observations' list page" name="Governance" url="../governance"></otp-navigation-item>
+    </otp-navigation>
   </div>
   <div class="c-button-container -j-end">
     <a class="c-button -primary" routerLink="../new" i18n="Button to create a new observation">New observation</a>

--- a/src/app/pages/observations/observation-list.component.scss
+++ b/src/app/pages/observations/observation-list.component.scss
@@ -1,4 +1,4 @@
-@import 'src/settings';
+@import 'src/settings.scss';
 
 :host {
   display: block;

--- a/src/app/pages/observations/observation-list.component.ts
+++ b/src/app/pages/observations/observation-list.component.ts
@@ -16,10 +16,6 @@ import { TableFilterBehavior } from 'app/shared/table-filter/table-filter.behavi
 })
 export class ObservationListComponent extends TableFilterBehavior {
 
-  navigationItems: NavigationItem[] = [
-      { name: 'Operators', url: '../operators' },
-      { name: 'Governance', url: '../governance' }
-    ];
   private selected = [];
   private editURL: string;
 

--- a/src/app/pages/page-not-found/page-not-found.component.html
+++ b/src/app/pages/page-not-found/page-not-found.component.html
@@ -1,8 +1,8 @@
 <div class="l-wrapper">
   <div class="container">
-    <h1 i18n>404. Page not found</h1>
-    <p i18n>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</p>
-    <a routerLink="/private/my-otp" class="c-button -primary" *ngIf="isLogged" i18n>Go to my OTP</a>
-    <a routerLink="/" class="c-button -primary" *ngIf="!isLogged" i18n>Go to login page</a>
+    <h1 i18n="404 page|Title of the page">404. Page not found</h1>
+    <p i18n="404 page|Description of the error">The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</p>
+    <a routerLink="/private/my-otp" class="c-button -primary" *ngIf="isLogged" i18n="404 page|Button to suggest the user to go to the 'My OTP' page">Go to my OTP</a>
+    <a routerLink="/" class="c-button -primary" *ngIf="!isLogged" i18n="404 page|Button to suggest the user to go to the login page">Go to login page</a>
   </div>
 </div>

--- a/src/app/pages/page-not-found/page-not-found.component.html
+++ b/src/app/pages/page-not-found/page-not-found.component.html
@@ -1,8 +1,8 @@
 <div class="l-wrapper">
   <div class="container">
-    <h1>404. Page not found</h1>
-    <p>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</p>
-    <a routerLink="/private/my-otp" class="c-button -primary" *ngIf="isLogged">Go to my OTP</a>
-    <a routerLink="/" class="c-button -primary" *ngIf="!isLogged">Go to login page</a>
+    <h1 i18n>404. Page not found</h1>
+    <p i18n>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</p>
+    <a routerLink="/private/my-otp" class="c-button -primary" *ngIf="isLogged" i18n>Go to my OTP</a>
+    <a routerLink="/" class="c-button -primary" *ngIf="!isLogged" i18n>Go to login page</a>
   </div>
 </div>

--- a/src/app/pages/register/register.component.html
+++ b/src/app/pages/register/register.component.html
@@ -1,47 +1,47 @@
 <div class="l-wrapper">
-  <h2>Register</h2>
+  <h2 i18n="Register page|Title of the page">Register</h2>
   <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
   <form name="form" (ngSubmit)="f.valid && onSubmit(f.value)" #f="ngForm" novalidate>
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !name.valid }">
-      <label for="name">Name</label>
+      <label for="name" i18n="Register page|Label for the name field (name of the person)">Name</label>
       <input id="name" type="text" class="form-control" name="name" ngModel #name="ngModel" required />
-      <div *ngIf="f.submitted && !name.valid" class="help-text">Name is required</div>
+      <div *ngIf="f.submitted && !name.valid" class="help-text" i18n="Register page|Error message if the name isn't supplied">Name is required</div>
     </div>
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !nickname.valid }">
-      <label for="nickname">Username</label>
+      <label for="nickname" i18n="Register page|Label for the username field (a nickname)">Username</label>
       <input id="nickname" type="text" class="form-control" name="nickname" ngModel #nickname="ngModel" required />
-      <div *ngIf="f.submitted && !nickname.valid" class="help-text">Username is required</div>
+      <div *ngIf="f.submitted && !nickname.valid" class="help-text" i18n="Register page|Error message if the username/nickname isn't supplied">Username is required</div>
     </div>
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !institution.valid }">
-      <label for="institution">Institution</label>
+      <label for="institution" i18n="Register page|Label for the institution field (name of the insitution, organization)">Institution</label>
       <input id="institution" type="text" class="form-control" name="institution" ngModel #institution="ngModel" required />
     </div>
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !country_id.valid }">
-      <label for="country_id">Country</label>
+      <label for="country_id" i18n="Register page|Label for the country field (the user will have to choose between some options)">Country</label>
       <select id="country_id" name="country_id" ngModel #country_id="ngModel" required>
         <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
       </select>
     </div>
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !email.valid }">
-      <label for="email">Email</label>
+      <label for="email" i18n="Register page|Label for the email field">Email</label>
       <input id="email" type="email" class="form-control" name="email" ngModel #email="ngModel" required email />
-      <p *ngIf="f.submitted && email.errors?.required" class="help-text">Email is required</p>
-      <p *ngIf="f.submitted && email.errors?.email && !email.errors?.required" class="help-text">Please enter an email address</p>
+      <p *ngIf="f.submitted && email.errors?.required" class="help-text" i18n="Register page|Error message if the email isn't supplied">Email is required</p>
+      <p *ngIf="f.submitted && email.errors?.email && !email.errors?.required" class="help-text" i18n="Register page|Error message if the email isn't valid">Please enter an email address</p>
     </div>
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !password.valid }">
-      <label for="password">Password</label>
+      <label for="password" i18n="Register page|Label for the password field">Password</label>
       <input id="password" type="password" class="form-control" name="password" ngModel #password="ngModel" required />
-      <div *ngIf="f.submitted && !password.valid" class="help-text">Password is required</div>
+      <div *ngIf="f.submitted && !password.valid" class="help-text" i18n="Register page|Error message if the password isn't supplied">Password is required</div>
     </div>
     <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !password_confirmation.valid }">
-      <label for="password_confirmation">Confirm your password</label>
+      <label for="password_confirmation" i18n="Register page|Label for the password confirmation field">Confirm your password</label>
       <input id="password_confirmation" type="password" ngModel class="form-control" name="password_confirmation" #password_confirmation="ngModel" [equalTo]="password" required />
-      <div *ngIf="f.submitted && password_confirmation.errors?.required" class="help-text">Please confirm your password</div>
-      <div *ngIf="f.submitted && password_confirmation.errors?.equalTo && !password_confirmation.errors?.required" class="help-text">Password values don't not coincide</div>
+      <div *ngIf="f.submitted && password_confirmation.errors?.required" class="help-text" i18n="Register page|Error message if the password confirmation isn't supplied">Please confirm your password</div>
+      <div *ngIf="f.submitted && password_confirmation.errors?.equalTo && !password_confirmation.errors?.required" class="help-text" i18n="Register page|Error message if the password and it's confirmation don't coincide">Password values don't not coincide</div>
     </div>
     <div class="c-button-container form-group">
-      <a [routerLink]="['/']" class="c-button -secondary">Login</a>
-      <button disable="loading" type="submit" class="c-button -primary">Register</button>
+      <a [routerLink]="['/']" class="c-button -secondary" i18n="Button to log in">Login</a>
+      <button disable="loading" type="submit" class="c-button -primary" i18n="Button to register">Register</button>
     </div>
   </form>
 </div>

--- a/src/app/pages/users/user-detail.component.html
+++ b/src/app/pages/users/user-detail.component.html
@@ -1,10 +1,16 @@
 <div class="l-wrapper">
   <spinner class="center" *ngIf="loading" [tickness]="1" [size]="20"></spinner>
   <div class="c-container -j-between">
-    <h2>{{mode === 'new' ? 'New' : 'Update'}} user</h2>
+    <h2>
+      <ng-template [ngIf]="mode === 'new'" i18n="User creation|Title of the page">New user</ng-template>
+      <ng-template [ngIf]="mode !== 'new'" i18n="User edition|Title of the page">Update user</ng-template>
+    </h2>
     <div class="c-button-container -j-end form-group" *otpMinTablet>
-      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-      <button disable="loading" type="submit" class="c-button -primary">{{mode === 'new' ? 'Create' : 'Update'}}</button>
+      <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+      <button disable="loading" type="submit" class="c-button -primary">
+        <ng-template [ngIf]="mode === 'new'" i18n="Create button">Create</ng-template>
+        <ng-template [ngIf]="mode !== 'new'" i18n="Update button">Update</ng-template>
+      </button>
     </div>
   </div>
 
@@ -12,31 +18,31 @@
     <div class="form-container">
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !name.valid }">
-        <label for="name">Name</label>
+        <label for="name" i18n="User creation/edition|Label for the name field (name of the person)">Name</label>
         <input id="name" type="text" class="form-control" name="name" [(ngModel)]="user && user.name" #name="ngModel" required />
-        <div *ngIf="f.submitted && !name.valid" class="help-text">Name is required</div>
+        <div *ngIf="f.submitted && !name.valid" class="help-text" i18n="User creation/edition|Error message if the name isn't supplied">Name is required</div>
       </div>
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !nickname.valid }">
-        <label for="nickname">Username</label>
+        <label for="nickname" i18n="User creation/edition|Label for the username field (a nickname)">Username</label>
         <input id="nickname" type="text" class="form-control" name="nickname" [(ngModel)]="user && user.nickname" #nickname="ngModel" required />
-        <div *ngIf="f.submitted && !nickname.valid" class="help-text">Username is required</div>
+        <div *ngIf="f.submitted && !nickname.valid" class="help-text" i18n="User creation/edition|Error message if the username/nickname isn't supplied">Username is required</div>
       </div>
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !email.valid }">
-        <label for="email">Email</label>
+        <label for="email" i18n="User creation/edition|Label for the email field">Email</label>
         <input id="email" type="email" class="form-control" name="email" [(ngModel)]="user && user.email" #email="ngModel" email required />
-        <div *ngIf="f.submitted && email.errors?.required" class="help-text">Email is required</div>
-        <div *ngIf="f.submitted && email.errors?.email && !email.errors?.required" class="help-text">Please enter an email address</div>
+        <div *ngIf="f.submitted && email.errors?.required" class="help-text" i18n="User creation/edition|Error message if the email isn't supplied">Email is required</div>
+        <div *ngIf="f.submitted && email.errors?.email && !email.errors?.required" class="help-text" i18n="User creation/edition|Error message if the email isn't valid">Please enter an email address</div>
       </div>
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !institution.valid }">
-        <label for="institution">Institution</label>
+        <label for="institution" i18n="User creation|Label for the institution field (name of the insitution, organization)">Institution</label>
         <input id="institution" type="text" class="form-control" name="institution" [(ngModel)]="user && user.institution" #institution="ngModel" />
       </div>
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !country_id.valid }">
-        <label for="country_id">Country</label>
+        <label for="country_id" i18n="User creation/edition|Label for the country field (the user will have to choose between some options)">Country</label>
         <select id="country_id" name="country_id" [(ngModel)]="user && user.country.id" #country_id="ngModel">
           <option *ngFor="let country of countries" [value]="country.id">{{ country.name }}</option>
         </select>
@@ -44,37 +50,43 @@
 
       <ng-template [ngIf]="mode === 'new'">
         <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !password.valid }">
-          <label for="password">Password</label>
+          <label for="password" i18n="User creation/edition|Label for the password field">Password</label>
           <input id="password" type="password" class="form-control" name="password" ngModel #password="ngModel" required />
-          <div *ngIf="f.submitted && !password.valid" class="help-text">Password is required</div>
+          <div *ngIf="f.submitted && !password.valid" class="help-text" i18n="User creation/edition|Error message if the password isn't supplied">Password is required</div>
         </div>
 
         <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !password_confirmation.valid }">
-          <label for="password_confirmation">Confirm your password</label>
+          <label for="password_confirmation" i18n="User creation/edition|Label for the password confirmation field">Confirm your password</label>
           <input id="password_confirmation" type="password" class="form-control" name="password_confirmation" ngModel #password_confirmation="ngModel" [equalTo]="password" required />
-          <div *ngIf="f.submitted && password_confirmation.errors?.required" class="help-text">Please confirm your password</div>
-          <div *ngIf="f.submitted && password_confirmation.errors?.equalTo && !password_confirmation.errors?.required" class="help-text">Password values don't not coincide</div>
+          <div *ngIf="f.submitted && password_confirmation.errors?.required" class="help-text" i18n="User creation/edition|Error message if the password confirmation isn't supplied">Please confirm your password</div>
+          <div *ngIf="f.submitted && password_confirmation.errors?.equalTo && !password_confirmation.errors?.required" class="help-text" i18n="User creation/edition|Error message if the password and its confirmation don't coincide'">Password values don't not coincide</div>
         </div>
       </ng-template>
 
       <div class="form-group" [ngClass]="{ 'has-error': f.submitted && !user_permission_attributes.valid }">
-        <label for="user_permission_attributes">Permissions</label>
+        <label for="user_permission_attributes" i18n="User creation|Label for the permissions field (the user will have to choose a role)">Permissions</label>
         <select id="user_permission_attributes" name="user_permission_attributes" [(ngModel)]="user && user.user_permission.user_role" #user_permission_attributes="ngModel">
-          <option value="admin">Admin</option>
-          <option value="ngo">NGO</option>
+          <option value="admin" i18n="User role">Admin</option>
+          <option value="ngo" i18n="User role">NGO</option>
         </select>
       </div>
     </div>
 
     <div class="form-footer">
       <div class="c-button-container -j-end form-group" *otpMinTablet>
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">{{mode === 'new' ? 'Create' : 'Update'}}</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary">
+          <ng-template [ngIf]="mode === 'new'" i18n="Create button">Create</ng-template>
+          <ng-template [ngIf]="mode !== 'new'" i18n="Update button">Update</ng-template>
+        </button>
       </div>
 
       <otp-action-bar *otpMaxTablet>
-        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary">Cancel</button>
-        <button disable="loading" type="submit" class="c-button -primary">{{mode === 'new' ? 'Create' : 'Update'}}</button>
+        <button disable="loading" type="button" (click)="onCancel()" class="c-button -secondary" i18n="Cancel button">Cancel</button>
+        <button disable="loading" type="submit" class="c-button -primary">
+          <ng-template [ngIf]="mode === 'new'" i18n="Create button">Create</ng-template>
+          <ng-template [ngIf]="mode !== 'new'" i18n="Update button">Update</ng-template>
+        </button>
       </otp-action-bar>
     </div>
   </form>

--- a/src/app/pages/users/user-list.component.html
+++ b/src/app/pages/users/user-list.component.html
@@ -1,17 +1,17 @@
 <div class="l-wrapper">
   <div class="c-container -j-between">
     <div class="c-button-container -j-end">
-      <button (click)="triggerNewUser()" class="c-button -primary">
+      <button (click)="triggerNewUser()" class="c-button -primary" i18n="Button to create a new user">
         New user
       </button>
     </div>
   </div>
 
-  <otp-table caption="Users">
-    <otp-table-column name="Name" prop="name"></otp-table-column>
-    <otp-table-column name="Username" prop="nickname"></otp-table-column>
-    <otp-table-column name="Email" prop="email"></otp-table-column>
-    <otp-table-column name="Actions">
+  <otp-table i18n-caption="Caption for the table which lists the users" caption="Users">
+    <otp-table-column i18n-name="Table of users|Name of the column corresponding to the name of the users" name="Name" prop="name"></otp-table-column>
+    <otp-table-column i18n-name="Table of users|Name of the column corresponding to the username/nickname of the users"  name="Username" prop="nickname"></otp-table-column>
+    <otp-table-column i18n-name="Table of users|Name of the column corresponding to the email of the users" name="Email" prop="email"></otp-table-column>
+    <otp-table-column i18n-name="Table of users|Name of the actions columns (containing the edit and delete button)" name="Actions">
      <ng-template let-row="row" table-cell-template>
        <button class="action" (click)="onEdit(row)"><otp-icon name="#icon-edit"></otp-icon></button>
        <button class="action" (click)="onDelete(row)"><otp-icon name="#icon-delete"></otp-icon></button>

--- a/src/app/services/oauth-request.service.ts
+++ b/src/app/services/oauth-request.service.ts
@@ -1,13 +1,16 @@
-import { NgModule, Injectable } from '@angular/core';
+import { NgModule, Inject, Injectable, LOCALE_ID } from '@angular/core';
 import { RequestOptions, RequestOptionsArgs, RequestMethod, Headers } from '@angular/http';
 import { TokenService } from 'app/services/token.service';
 import { environment } from 'environments/environment';
 
 @Injectable()
 export class OauthRequestOptions extends RequestOptions {
-  constructor (private tokenService: TokenService) {
-    super();
 
+  constructor (
+    private tokenService: TokenService,
+    @Inject(LOCALE_ID) private locale: string
+  ) {
+    super();
   }
 
   merge(options?: RequestOptionsArgs): RequestOptions {
@@ -19,6 +22,14 @@ export class OauthRequestOptions extends RequestOptions {
       options.headers.set('Authorization', `Bearer ${this.tokenService.token}`);
     }
     options.headers.set('OTP-API-KEY', environment.OTP_API_KEY);
+
+    if (!options.search || !options.search['locale']) {
+      if (!options.search) {
+        options.search = {};
+      }
+
+      options.search['locale'] = this.locale.slice(0, 2);
+    }
 
     return super.merge(options);
   }

--- a/src/app/shared/bottom-bar/bottom-bar.component.html
+++ b/src/app/shared/bottom-bar/bottom-bar.component.html
@@ -1,5 +1,5 @@
-<a role="menuitem" routerLink="/private/my-otp" routerLinkActive="-active">My OTP</a>
-<a role="menuitem" routerLink="/private/observations" routerLinkActive="-active">Observations</a>
-<a role="menuitem" routerLink="/private/fields" routerLinkActive="-active">Fields</a>
-<a role="menuitem" *ngIf="isAdmin" routerLink="/private/users" routerLinkActive="-active">Users</a>
+<a role="menuitem" routerLink="/private/my-otp" routerLinkActive="-active" i18n="My OTP menu option">My OTP</a>
+<a role="menuitem" routerLink="/private/observations" routerLinkActive="-active" i18n="Observations menu option">Observations</a>
+<a role="menuitem" routerLink="/private/fields" routerLinkActive="-active" i18n="Fields menu option">Fields</a>
+<a role="menuitem" *ngIf="isAdmin" routerLink="/private/users" routerLinkActive="-active" i18n="Users menu option">Users</a>
 <!--<a role="menuitem" routerLink="profile" routerLinkActive="-active">Profile</a>-->

--- a/src/app/shared/bottom-bar/bottom-bar.component.html
+++ b/src/app/shared/bottom-bar/bottom-bar.component.html
@@ -1,5 +1,5 @@
-<a role="menuitem" routerLink="/private/my-otp" routerLinkActive="-active" i18n="My OTP menu option">My OTP</a>
-<a role="menuitem" routerLink="/private/observations" routerLinkActive="-active" i18n="Observations menu option">Observations</a>
-<a role="menuitem" routerLink="/private/fields" routerLinkActive="-active" i18n="Fields menu option">Fields</a>
-<a role="menuitem" *ngIf="isAdmin" routerLink="/private/users" routerLinkActive="-active" i18n="Users menu option">Users</a>
+<a role="menuitem" routerLink="/private/my-otp" routerLinkActive="-active" i18n="Menu item|Main navigation menu (mobile)">My OTP</a>
+<a role="menuitem" routerLink="/private/observations" routerLinkActive="-active" i18n="Menu item|Main navigation menu (mobile)">Observations</a>
+<a role="menuitem" routerLink="/private/fields" routerLinkActive="-active" i18n="Menu item|Main navigation menu (mobile)">Fields</a>
+<a role="menuitem" *ngIf="isAdmin" routerLink="/private/users" routerLinkActive="-active" i18n="Menu item|Main navigation menu (mobile)">Users</a>
 <!--<a role="menuitem" routerLink="profile" routerLinkActive="-active">Profile</a>-->

--- a/src/app/shared/bottom-bar/bottom-bar.component.scss
+++ b/src/app/shared/bottom-bar/bottom-bar.component.scss
@@ -4,7 +4,7 @@
   position: fixed;
   display: flex;
   justify-content: space-between;
-  padding: 0 20px;
+  padding: 0 10px;
   width: 100%;
   overflow: hidden;
   bottom: 0;
@@ -16,8 +16,8 @@
     position: relative;
     height: $bottom-bar-height;
     color: $black;
-    margin-bottom: 0;
-    font-size: $font-size-default;
+    margin: 0 10px 0 0;
+    font-size: $font-size-small;
     text-decoration: none;
     line-height: $bottom-bar-height;
     text-align: center;
@@ -33,6 +33,10 @@
       height: 6px;
       background-color: $color-primary;
       content: '';
+    }
+
+    &:last-of-type {
+      margin-right: 0;
     }
   }
 }

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -7,6 +7,11 @@
     </ul>
   </div>
   <ng-template [ngIf]="isLogged">
-    <otp-navigation [items]="navigationItems" (change)="onChange($event)" *otpMinTablet></otp-navigation>
+    <otp-navigation (change)="onChange($event)" *otpMinTablet>
+      <otp-navigation-item i18n-name="Menu item|Main navigation menu (desktop)" name="My OTP" url="/private/my-otp"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Main navigation menu (desktop)" name="Observations" url="/private/observations"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Main navigation menu (desktop)" name="Observation fields" url="/private/fields"></otp-navigation-item>
+      <otp-navigation-item i18n-name="Menu item|Main navigation menu (desktop)" name="Users" url="/private/users" *ngIf="isAdmin"></otp-navigation-item>
+    </otp-navigation>
   </ng-template>
 </div>

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -2,7 +2,12 @@
   <div class="menu">
     <img src="assets/OTP-logo.svg" i18n-alt="Name of the app" alt="Open Timber Portal" />
     <ul>
-      <li>English</li>
+      <li>
+        <select [(ngModel)]="lang" (change)="onChangeLanguage()">
+          <option value="en">English</option>
+          <option value="fr">Français</option>
+        </select>
+      </li>
       <li *ngIf="isLogged"><button type="button" (click)="logout()" i18n="Log out button">Log out</button></li>
     </ul>
   </div>

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -1,9 +1,9 @@
 <div class="l-wrapper">
   <div class="menu">
-    <img src="assets/OTP-logo.svg" alt="Open Timber Portal" />
+    <img src="assets/OTP-logo.svg" i18n-alt="Name of the app" alt="Open Timber Portal" />
     <ul>
       <li>English</li>
-      <li *ngIf="isLogged"><button type="button" (click)="logout()">Log out</button></li>
+      <li *ngIf="isLogged"><button type="button" (click)="logout()" i18n="Log out button">Log out</button></li>
     </ul>
   </div>
   <ng-template [ngIf]="isLogged">

--- a/src/app/shared/header/header.component.scss
+++ b/src/app/shared/header/header.component.scss
@@ -19,12 +19,14 @@
       list-style: none;
 
       li {
-        margin-right: 10px;
         padding: 0 10px;
         color: $grey;
 
+        @media screen and (min-width: $break-tablet) {
+          padding: 0 20px;
+        }
+
         &:last-of-type {
-          margin-right: 0;
           padding-right: 0;
           cursor: pointer;
         }
@@ -35,6 +37,14 @@
           font-size: inherit;
         }
       }
+    }
+
+    select {
+      margin: 0;
+      padding: 0 10px 0 0;
+      border: 0;
+      box-shadow: none;
+      background-position: right -10px center;
     }
   }
 

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { Component, Inject, LOCALE_ID } from '@angular/core';
 import { AuthService } from 'app/services/auth.service';
 import { NavigationItem } from 'app/shared/navigation/navigation.component';
 
@@ -11,13 +12,30 @@ export class HeaderComponent {
 
   private isAdmin = false;
   isLogged = false;
+  lang: string;
 
-  constructor (private authService: AuthService) {
+  constructor (
+    private authService: AuthService,
+    private router: Router,
+    private route: ActivatedRoute,
+    @Inject(LOCALE_ID) locale: string
+  ) {
+    this.lang = locale.slice(0, 2);
+
     // Each time the status of the login change, we update some variables
     this.authService.loginStatus.subscribe(isLogged => {
       this.isLogged = isLogged;
       this.authService.isAdmin().then(isAdmin => this.isAdmin = isAdmin);
     });
+  }
+
+  onChangeLanguage() {
+    // We update the lang query param and reload the app so the other
+    // bundle can be loaded
+    this.router.navigate([], {
+      queryParams: { lang: this.lang },
+      relativeTo: this.route
+    }).then(() => location.reload());
   }
 
   logout(): void {

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -12,19 +12,6 @@ export class HeaderComponent {
   private isAdmin = false;
   isLogged = false;
 
-  private _navigationItems: NavigationItem[] = [
-    { name: 'My OTP', url: '/private/my-otp'},
-    { name: 'Observations', url: '/private/observations' },
-    { name: 'Observation fields', url: '/private/fields' },
-    { name: 'Users', url: '/private/users' },
-  ];
-
-  get navigationItems(): NavigationItem[] {
-    return this.isAdmin
-      ? this._navigationItems
-      : this._navigationItems.slice(0, 3);
-  }
-
   constructor (private authService: AuthService) {
     // Each time the status of the login change, we update some variables
     this.authService.loginStatus.subscribe(isLogged => {

--- a/src/app/shared/navigation/directives/item/item.directive.ts
+++ b/src/app/shared/navigation/directives/item/item.directive.ts
@@ -1,0 +1,13 @@
+import { Directive, Input, ContentChild, TemplateRef } from '@angular/core';
+
+@Directive({
+  // tslint:disable-next-line:directive-selector
+  selector: 'otp-navigation-item'
+})
+export class NavigationItemDirective {
+
+  @Input() name: string;
+  @Input() url: string;
+  @Input() exact = false;
+
+}

--- a/src/app/shared/navigation/navigation.component.html
+++ b/src/app/shared/navigation/navigation.component.html
@@ -1,6 +1,6 @@
 <ul [class]="'-' + this.layout">
-    <li *ngFor="let item of items" [class.-active]="isActive(item)">
-      <a *ngIf="item.url" [routerLink]="item.url" (click)="onClick(item)">{{item.name}}</a>
-      <button *ngIf="!item.url" type="button" (click)="onClick(item)">{{item.name}}</button>
-    </li>
+  <li *ngFor="let item of items" [class.-active]="isActive(item)">
+    <a *ngIf="item.url" [routerLink]="item.url" (click)="onClick(item)">{{item.name}}</a>
+    <button *ngIf="!item.url" type="button" (click)="onClick(item)">{{item.name}}</button>
+  </li>
 </ul>

--- a/src/app/shared/navigation/navigation.component.ts
+++ b/src/app/shared/navigation/navigation.component.ts
@@ -1,5 +1,6 @@
+import { NavigationItemDirective } from './directives/item/item.directive';
 import { Router, ActivatedRoute } from '@angular/router';
-import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ContentChildren, QueryList, AfterContentInit } from '@angular/core';
 
 export interface NavigationItem {
   name: string;
@@ -14,17 +15,19 @@ export interface NavigationItem {
   templateUrl: './navigation.component.html',
   styleUrls: ['./navigation.component.scss']
 })
-export class NavigationComponent implements OnInit {
+export class NavigationComponent implements AfterContentInit {
 
   @Input() private activeItem: NavigationItem;
-  @Input() items: NavigationItem[] = [];
   @Input() layout: 'mini'|'horizontal'|'vertical' = 'horizontal';
   @Output() private change = new EventEmitter();
+
+  @ContentChildren(NavigationItemDirective)
+  items: QueryList<NavigationItemDirective>;
 
   // Whether or not the component should manage which item is active
   // If not, the router will automatically determine it
   private get manageActiveItem(): boolean {
-    return this.items.reduce((res, item) => res || !item.url, false);
+    return this.items.toArray().reduce((res, item) => res || !item.url, false);
   }
 
   constructor (
@@ -32,10 +35,10 @@ export class NavigationComponent implements OnInit {
     private activedRoute: ActivatedRoute
   ) {}
 
-  ngOnInit(): void {
+  ngAfterContentInit(): void {
     // We always set a default active item
-    if (this.manageActiveItem && !this.activeItem && this.items.length) {
-      this.activeItem = this.items[0];
+    if (this.manageActiveItem && !this.activeItem && this.items.toArray().length) {
+      this.activeItem = this.items.first;
     }
   }
 
@@ -46,7 +49,7 @@ export class NavigationComponent implements OnInit {
    */
   private onClick(item: NavigationItem): void {
     if (this.manageActiveItem) {
-      this.activeItem = this.items.find(i => {
+      this.activeItem = this.items.toArray().find(i => {
         return i === item;
       });
     }

--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -2,9 +2,10 @@
 <otp-loader *ngIf="loading" [attr.class]="rows && rows.length && rows.length > 1 ? '-has-data' : ''"></otp-loader>
 <table role="grid" aria-readonly="true" [attr.aria-rowcount]="rowCount">
   <caption>
-    {{caption || 'Undefined table'}}
+    <ng-template [ngIf]="caption">{{caption}}</ng-template>
+    <ng-template [ngIf]="!caption" i18n="Default caption for the tables">Undefined table</ng-template>
     <ng-template [ngIf]="sortColumn">
-      , sorted by {{sortColumn.name || sortColumn.prop}}: {{sortOrder}}
+      <span i18n="Complementary caption information">, sorted by</span> {{sortColumn.name || sortColumn.prop}}: {{sortOrder}}
     </ng-template>
   </caption>
 
@@ -45,7 +46,7 @@
 </table>
 
 <div *ngIf="perPage" class="paginator">
-  <button type="button" class="c-button -secondary" [disabled]="!previousPage" (click)="currentPage = previousPage">Previous</button>
+  <button type="button" class="c-button -secondary" [disabled]="!previousPage" (click)="currentPage = previousPage" i18n="Table paginator|Previous page button">Previous</button>
   <ul>
     <li *ngIf="currentPage > firstPage + 1"><button type="button" [attr.aria-label]="'Page ' + firstPage" (click)="currentPage = firstPage">{{firstPage}}</button></li>
     <li *ngIf="currentPage > firstPage + 2">...</li>
@@ -55,5 +56,5 @@
     <li *ngIf="currentPage < lastPage - 2">...</li>
     <li *ngIf="currentPage < lastPage - 1"><button type="button" [attr.aria-label]="'Page ' + lastPage" (click)="currentPage = lastPage">{{lastPage}}</button></li>
   </ul>
-  <button type="button" class="c-button -secondary" [disabled]="!nextPage" (click)="currentPage = nextPage">Next</button>
+  <button type="button" class="c-button -secondary" [disabled]="!nextPage" (click)="currentPage = nextPage" i18n="Table paginator|Next page button">Next</button>
 </div>

--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -5,7 +5,7 @@
     <ng-template [ngIf]="caption">{{caption}}</ng-template>
     <ng-template [ngIf]="!caption" i18n="Default caption for the tables">Undefined table</ng-template>
     <ng-template [ngIf]="sortColumn">
-      <span i18n="Complementary caption information">, sorted by</span> {{sortColumn.name || sortColumn.prop}}: {{sortOrder}}
+      <span i18n="Complementary caption information">, sorted by</span> {{sortColumn.name || sortColumn.prop}}: <span i18n="Sort order of the table" *ngIf="sortOrder === 'asc'">ascendent</span><span i18n="Sort order of the table" *ngIf="sortOrder === 'desc'">descendent</span>
     </ng-template>
   </caption>
 
@@ -45,16 +45,18 @@
 
 </table>
 
+<span #pageWordTranslation i18n="Table paginator|Page of a table" hidden style="display: none;">Page</span>
+
 <div *ngIf="perPage" class="paginator">
   <button type="button" class="c-button -secondary" [disabled]="!previousPage" (click)="currentPage = previousPage" i18n="Table paginator|Previous page button">Previous</button>
   <ul>
-    <li *ngIf="currentPage > firstPage + 1"><button type="button" [attr.aria-label]="'Page ' + firstPage" (click)="currentPage = firstPage">{{firstPage}}</button></li>
+    <li *ngIf="currentPage > firstPage + 1"><button type="button" [attr.aria-label]="pageWord + ' ' + firstPage" (click)="currentPage = firstPage">{{firstPage}}</button></li>
     <li *ngIf="currentPage > firstPage + 2">...</li>
-    <li *ngIf="previousPage"><button type="button" [attr.aria-label]="'Page ' + previousPage" (click)="currentPage = previousPage">{{previousPage}}</button></li>
-    <li class="-active"><button type="button" [attr.aria-label]="'Page ' + currentPage">{{currentPage}}</button></li>
-    <li *ngIf="nextPage"><button type="button" [attr.aria-label]="'Page ' + nextPage" (click)="currentPage = nextPage">{{nextPage}}</button></li>
+    <li *ngIf="previousPage"><button type="button" [attr.aria-label]="pageWord + ' ' + previousPage" (click)="currentPage = previousPage">{{previousPage}}</button></li>
+    <li class="-active"><button type="button" [attr.aria-label]="pageWord + ' ' + currentPage">{{currentPage}}</button></li>
+    <li *ngIf="nextPage"><button type="button" [attr.aria-label]="pageWord + ' ' + nextPage" (click)="currentPage = nextPage">{{nextPage}}</button></li>
     <li *ngIf="currentPage < lastPage - 2">...</li>
-    <li *ngIf="currentPage < lastPage - 1"><button type="button" [attr.aria-label]="'Page ' + lastPage" (click)="currentPage = lastPage">{{lastPage}}</button></li>
+    <li *ngIf="currentPage < lastPage - 1"><button type="button" [attr.aria-label]="pageWord + ' ' + lastPage" (click)="currentPage = lastPage">{{lastPage}}</button></li>
   </ul>
   <button type="button" class="c-button -secondary" [disabled]="!nextPage" (click)="currentPage = nextPage" i18n="Table paginator|Next page button">Next</button>
 </div>

--- a/src/app/shared/table/table.component.ts
+++ b/src/app/shared/table/table.component.ts
@@ -1,5 +1,5 @@
 import { TABLET_BREAKPOINT } from 'app/directives/responsive.directive';
-import { Component, Input, QueryList, ContentChildren, EventEmitter, Output } from '@angular/core';
+import { Component, Input, QueryList, ContentChildren, EventEmitter, Output, ElementRef, AfterContentInit, ViewChild } from '@angular/core';
 import { TableColumnDirective } from 'app/shared/table/directives/column/column.directive';
 
 export interface TableState {
@@ -14,7 +14,7 @@ export interface TableState {
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.scss']
 })
-export class TableComponent {
+export class TableComponent implements AfterContentInit {
 
   public rows: any[] = [];
   public rowCount: number; // Number of total rows (total results)
@@ -27,6 +27,7 @@ export class TableComponent {
   columns: any[] = [];
   sortColumn: any; // Column used for sorting the table
   sortOrder: 'asc'|'desc'; // Sort order
+  pageWord: string; // Word to say page in the current language
 
   private _columnTemplates: QueryList<TableColumnDirective>;
   private _paginationIndex = 0; // Zero-based number of the page
@@ -75,6 +76,13 @@ export class TableComponent {
         }
       }
     }
+  }
+
+  @ViewChild('pageWordTranslation', { read: ElementRef })
+  pageTranslationNode: ElementRef;
+
+  ngAfterContentInit(): void {
+    this.pageWord = this.pageTranslationNode.nativeElement.textContent;
   }
 
   get columnTemplates(): QueryList<TableColumnDirective> {

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -60,12 +60,40 @@
         </context-group>
         <note priority="1" from="description">Complementary caption information</note>
       </trans-unit>
+      <trans-unit id="6e0fa4af5418a615a1a09c67e32682e6b69c0f79" datatype="html">
+        <source>ascendent</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Sort order of the table</note>
+      </trans-unit>
+      <trans-unit id="547d6a7a6de920a2aefc34eeec1b9fc3d393bbb8" datatype="html">
+        <source>descendent</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Sort order of the table</note>
+      </trans-unit>
+      <trans-unit id="6219cbb729e72ee75b30c2ce46d7959d1d09aa8d" datatype="html">
+        <source>Page</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <note priority="1" from="description">Page of a table</note>
+        <note priority="1" from="meaning">Table paginator</note>
+      </trans-unit>
       <trans-unit id="e3706b34167ca5b613defa8be3a5d4c6316741e5" datatype="html">
         <source>Previous</source>
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">51</context>
         </context-group>
         <note priority="1" from="description">Previous page button</note>
         <note priority="1" from="meaning">Table paginator</note>
@@ -75,7 +103,7 @@
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">61</context>
         </context-group>
         <note priority="1" from="description">Next page button</note>
         <note priority="1" from="meaning">Table paginator</note>

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -2,37 +2,3465 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
-      <trans-unit id="aa112aafab99fca60e770e78dcc5d3c27f8ec4f4" datatype="html">
+      <trans-unit id="4f7091778907548985c8b4a592fa68e0f4c3368e" datatype="html">
         <source>404. Page not found</source>
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">3</context>
         </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">404 page</note>
       </trans-unit>
-      <trans-unit id="b66a22023a03f8985f17e59380711f3b5a099e53" datatype="html">
+      <trans-unit id="7b899c5c53c6d77238cbc42d49e17dcac27ba085" datatype="html">
         <source>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</source>
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">4</context>
         </context-group>
+        <note priority="1" from="description">Description of the error</note>
+        <note priority="1" from="meaning">404 page</note>
       </trans-unit>
-      <trans-unit id="641c31c001d58979956c8cb20082d85f6d8ae541" datatype="html">
+      <trans-unit id="7fb2c801d64dddc6287ab33765a74490ff471cc3" datatype="html">
         <source>Go to my OTP</source>
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">5</context>
         </context-group>
+        <note priority="1" from="description">Button to suggest the user to go to the &apos;My OTP&apos; page</note>
+        <note priority="1" from="meaning">404 page</note>
       </trans-unit>
-      <trans-unit id="ef691d3c76b2fa1584de7943391598624e64e1bc" datatype="html">
+      <trans-unit id="e32a02d7bc279823ef3a51428092c600cc181612" datatype="html">
         <source>Go to login page</source>
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">6</context>
         </context-group>
+        <note priority="1" from="description">Button to suggest the user to go to the login page</note>
+        <note priority="1" from="meaning">404 page</note>
+      </trans-unit>
+      <trans-unit id="bebaee9b83b435336940bd0f6bbecbefb8b81470" datatype="html">
+        <source>Undefined table</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Default caption for the tables</note>
+      </trans-unit>
+      <trans-unit id="5a97a400bac7feaf727c8bf556aaef97e34d82ea" datatype="html">
+        <source>, sorted by</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Complementary caption information</note>
+      </trans-unit>
+      <trans-unit id="e3706b34167ca5b613defa8be3a5d4c6316741e5" datatype="html">
+        <source>Previous</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <note priority="1" from="description">Previous page button</note>
+        <note priority="1" from="meaning">Table paginator</note>
+      </trans-unit>
+      <trans-unit id="274039dd3b5e706302cf2c3c433ea450bdd49703" datatype="html">
+        <source>Next</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <note priority="1" from="description">Next page button</note>
+        <note priority="1" from="meaning">Table paginator</note>
+      </trans-unit>
+      <trans-unit id="fa9b7116761f013fe509c7646dee9d1e9c3cc31a" datatype="html">
+        <source>Name of the organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field (name of the organization)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="d5035c69fba58edb578fe982eb8a03175f494319" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name of the organization isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="43ecccfbfb54901f26ce0d24939dbfff4315e553" datatype="html">
+        <source>Address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Label for the address field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="5aa48f8e4b18078364f9fa7af5fd13b8a4ade535" datatype="html">
+        <source>Address is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the address isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="7a19016a7b3167d2713f39b788e5e7d80f3f737d" datatype="html">
+        <source>Contact information (General information)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="1bb6270fc515c0526e262c35cf24ba9cf34bf917" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+        <note priority="1" from="description">Label for the contact&apos;s name field (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="caff929db9ef4d149aee1cc57926540ee74b88db" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <note priority="1" from="description">Label for the contact&apos;s email field (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="d642a03eb15d9e04e7577d51323276179b7324e2" datatype="html">
+        <source>Email is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the contact email isn&apos;t supplied (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="f5de8925e983f8662cf13f3f03d94643ba8eee8c" datatype="html">
+        <source>Please enter an email address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the contact email isn&apos;t valid (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="ddabada26b82beaa67cb0b3fdcf54a282921afe1" datatype="html">
+        <source>Phone number</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <note priority="1" from="description">Label for the contact&apos;s phone number field (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="178268700e3527de634d28f7e397b10a5cecd7a0" datatype="html">
+        <source>Phone number is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the contact phone number isn&apos;t supplied (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="15681d9d8184e095004288f60aace675ddc8e930" datatype="html">
+        <source>Contact information (For inquiries on data uploaded)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="8056edf01468679e6f762fece7279fd0a31c0474" datatype="html">
+        <source>Type of organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <note priority="1" from="description">Label for the type of organization field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="286a22f1d01b750cc5f9fe1fc0053494c4fb9411" datatype="html">
+        <source>Non governmental organization (NGO)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="8ae0be16277ef1c4b8c160c21c709addaafdf4b7" datatype="html">
+        <source>Academic</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="6de33973fba79ddbbc39cf39c100d1818d363ab1" datatype="html">
+        <source>Research Institute</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="9afb9078f854a9c32cdf55d49309ef19b5b6338d" datatype="html">
+        <source>Private company</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">80</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="c2a9de3714f5767b174d0424bc8abe2dc37acc41" datatype="html">
+        <source>Other</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="77ddb384bda36384bf19fd82da34668638cd1237" datatype="html">
+        <source>Please select a type of organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the type of organization isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="c1351de8b39808e0f027828afbaf48eafbefb36c" datatype="html">
+        <source>Please specify:</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">104</context>
+        </context-group>
+        <note priority="1" from="description">Label of an additional field where the user is asked to specify/detail a previous field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="2c67985932f0441af58f46be0b153bd30f39c5d9" datatype="html">
+        <source>Type of organization is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">89</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the &apos;more specific&apos; type of organization field isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="820d568fbf0cde2dd31e9f7d95fd4496a201189f" datatype="html">
+        <source>Type of monitoring organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <note priority="1" from="description">Label for the type of monitoring organization field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="b06f369749b6fb40f9373986c261c239898aae3e" datatype="html">
+        <source>Mandated</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <note priority="1" from="description">type of monitoring organization</note>
+      </trans-unit>
+      <trans-unit id="f06a9f71b004266aee89162657ea1c86d1315553" datatype="html">
+        <source>Semi mandated</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">type of monitoring organization</note>
+      </trans-unit>
+      <trans-unit id="b56d7b02a4200f20c0f4889025281c8280e88f09" datatype="html">
+        <source>Non-mandated (external)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+        <note priority="1" from="description">type of monitoring organization</note>
+      </trans-unit>
+      <trans-unit id="683a0fe8c12c2ce250c6dd5194f545ae7748db21" datatype="html">
+        <source>Please select a type of monitoring organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">100</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the type of monitoring organization isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="ea6416e29a89c5c714e69d898daba32eb41b698a" datatype="html">
+        <source>Type of monitoring organization is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the &apos;more specific&apos; type of monitoring organization field isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="3f26932174625c41427110ccc2226e504f5c6fbd" datatype="html">
+        <source>Current independent monitoring project</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">110</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="bf8439c857331fc455d3d031b6e2c60acf4389a9" datatype="html">
+        <source>Project title</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">115</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">199</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">244</context>
+        </context-group>
+        <note priority="1" from="description">Label for the project title field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="b2140291449def6677aa53569b3c48d84a56c20b" datatype="html">
+        <source>Project title is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">117</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the project title isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="8c78e20470679aab2f535754cbe129b99bb2df87" datatype="html">
+        <source>Lead organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">121</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">204</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">249</context>
+        </context-group>
+        <note priority="1" from="description">Label for the lead organization field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="e4f0576d34d9e84843eacd1a69357b464c2778bd" datatype="html">
+        <source>Lead organization is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">123</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the lead organization of a project isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="7fdfd037df64f59dcc2e76a327cd2706aa70dd5d" datatype="html">
+        <source>Start date</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">254</context>
+        </context-group>
+        <note priority="1" from="description">Label for the start date field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="3aba988d313ad1e91e0422e04026526c026e4344" datatype="html">
+        <source>Start date is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">129</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the start date of a project isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="a4cecf67712a605f7eb501374d3265fd12478cec" datatype="html">
+        <source>Project duration (years)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">133</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">214</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">259</context>
+        </context-group>
+        <note priority="1" from="description">Label for the duration in years field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="32acf484fd94a7bbb5192328b88f846d21f96fb3" datatype="html">
+        <source>Project duration is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">135</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the duration in years of a project isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="8a56af3ab6bb5ee118d69244fac33c11ab40a24b" datatype="html">
+        <source>Donor(s)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">139</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">219</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">264</context>
+        </context-group>
+        <note priority="1" from="description">Label for the donor(s) field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="d1be0cb8729481903a941dcc95235e5df34d1144" datatype="html">
+        <source>Donor(s) is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">141</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the donor(s) isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="6fd3fac713c24d0b1eb41ae210a92956dc47e067" datatype="html">
+        <source>Project website</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">145</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">224</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">269</context>
+        </context-group>
+        <note priority="1" from="description">Label for the website URL field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="61db125afe28f6cda94785420bbad6344cd6db25" datatype="html">
+        <source>Additional information on status, progress, etc.</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">150</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">229</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">274</context>
+        </context-group>
+        <note priority="1" from="description">Label for the additional information field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="49819b177c45f46e71178ef87bc2888c67948703" datatype="html">
+        <source>Website link</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">161</context>
+        </context-group>
+        <note priority="1" from="description">Label for the website URL field (of the organization)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="dfc9e62e50d1da01fa8fd0b6b7bcc02a6816d784" datatype="html">
+        <source>Organisation’s mission (max 250 characters)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+        <note priority="1" from="description">Label for the organization&apos;s mission field (with a limit of 250 chars)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="e132818042799ae0d6af75d59ecfe7ad2997a9c5" datatype="html">
+        <source>You exceed the maximum number of characters</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">168</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">174</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the organization&apos;s mission exceeds 250 chars</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="6bf5e59e896974c50b48e83196c5cf1b334791cb" datatype="html">
+        <source>Quality control (max 500 characters)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">172</context>
+        </context-group>
+        <note priority="1" from="description">Label for the quality control process field (with a limit of 500 chars)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="9714e9ae169a4c3cd16f982682d05002706c3e75" datatype="html">
+        <source>Geographical scope of work</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <note priority="1" from="description">Label for the organization&apos;s geographical scope field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="c7ec8a666155407083e0df211e21f1bddc5b5304" datatype="html">
+        <source>Sub-national</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">180</context>
+        </context-group>
+        <note priority="1" from="description">Geographical scope of an organization</note>
+      </trans-unit>
+      <trans-unit id="4ebd5411731ecbd28a246b00fbe62d5e76356d36" datatype="html">
+        <source>National</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">181</context>
+        </context-group>
+        <note priority="1" from="description">Geographical scope of an organization</note>
+      </trans-unit>
+      <trans-unit id="cb683c4a7564df4ad793eedad2a5ac342ecf5c12" datatype="html">
+        <source>International</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">182</context>
+        </context-group>
+        <note priority="1" from="description">Geographical scope of an organization</note>
+      </trans-unit>
+      <trans-unit id="d3cbd7eedb32d830d50c4ca6e0f2440b00af4c6c" datatype="html">
+        <source>Project 1</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">194</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="c518f75c849d225f2ca6141925c505dd9606ec2e" datatype="html">
+        <source>Project 2</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">239</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="6a6369d9cf34dd7374275a93fea20c243877bf99" datatype="html">
+        <source>Less details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">291</context>
+        </context-group>
+        <note priority="1" from="description">Less details button</note>
+      </trans-unit>
+      <trans-unit id="711a50f8cce91ebfb36614abe4e25c400480c269" datatype="html">
+        <source>More details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">292</context>
+        </context-group>
+        <note priority="1" from="description">More details button</note>
+      </trans-unit>
+      <trans-unit id="b4b9d2e75328589d6f50655d26d370b8a8168365" datatype="html">
+        <source>Discard changes</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">303</context>
+        </context-group>
+        <note priority="1" from="description">Discard change button</note>
+      </trans-unit>
+      <trans-unit id="5b3075e8dc3f3921ec316b0bd83b6d14a06c1a4f" datatype="html">
+        <source>Save changes</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">304</context>
+        </context-group>
+        <note priority="1" from="description">Save changes button</note>
+      </trans-unit>
+      <trans-unit id="dafa8a6b3ce5af28ce08ad9b57a82328126b5003" datatype="html">
+        <source>Update observation</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Observation edition</note>
+      </trans-unit>
+      <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
+        <source>Cancel</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">141</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">147</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">85</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">135</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">141</context>
+        </context-group>
+        <note priority="1" from="description">Cancel button</note>
+      </trans-unit>
+      <trans-unit id="047f50bc5b5d17b5bec0196355953e1a5c590ddb" datatype="html">
+        <source>Update</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">142</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">148</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">80</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">88</context>
+        </context-group>
+        <note priority="1" from="description">Update button</note>
+      </trans-unit>
+      <trans-unit id="2ced27c89ab044b68b5fc5f112e9fdb823d78073" datatype="html">
+        <source>Type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Label for the type field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
+        <source>Operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <note priority="1" from="description">Observation type</note>
+      </trans-unit>
+      <trans-unit id="edd600fa489d1b4a4448dce694ed932e52ce8fda" datatype="html">
+        <source>Governance</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Observation type</note>
+      </trans-unit>
+      <trans-unit id="8ac4ffef0bab3e3fef5a739f8f0659a27edbf5ab" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="66c8bc89c06a678f7956435165f15539fb6fcbf9" datatype="html">
+        <source>Please select a country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f81df4984ec9a7a25ca1a255e70c37cf0b3fc768" datatype="html">
+        <source>Latitude</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <note priority="1" from="description">Label for the latitude field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="9103deeab9ec8e9c404a9b613f32c40f8b81435b" datatype="html">
+        <source>Latitude is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the latitude isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="4d643d02cb8a26d011ecbc2cc65e36d6c79285b6" datatype="html">
+        <source>Please enter a valid number</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the latitude isn&apos;t valid</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="bcb1edd093495a7f451ec73bda71a390fd9b7bb0" datatype="html">
+        <source>Longitude</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <note priority="1" from="description">Label for the longitude field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="dfe47cc2c10ef51aec72676718979323da406949" datatype="html">
+        <source>Longitude is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the longitude isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="47147103a9753d3a57d16858149ad097aef3a20c" datatype="html">
+        <source>Sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+        <note priority="1" from="description">Label for the sub-category field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6bedd241a7533daaee02997b78ec87bdd2d2fb5a" datatype="html">
+        <source>Please select a sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the sub-category isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2836d984c7fd9f88dde6ca18f69d18ae66c268e2" datatype="html">
+        <source>Severity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <note priority="1" from="description">Label for the severity field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="4f9d0961548c19b80893a1354e2ffd8dad7347f4" datatype="html">
+        <source>Please select a severity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the severity isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1497e5043b0c1da86c5469b69d4c7497ff523438" datatype="html">
+        <source>Publication date</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <note priority="1" from="description">Label for the publication date field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="849521cde58edf20f3e8b3d596c0b4843603b3e8" datatype="html">
+        <source>Publication date is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the publication date isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="59cfebb84dc089e652e54b56dfd1127f5331bd8c" datatype="html">
+        <source>Government Entity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <note priority="1" from="description">Label for the government entity field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f0fd741b7784b50be4e7de22cc464106848b6673" datatype="html">
+        <source>Please select a government entity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the government entity isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="755a1c920f1be9572a38de2d2b0dda3b701c78f4" datatype="html">
+        <source>PV</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+        <note priority="1" from="description">Label for the PV field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="7ced18ad4df34b20929de05b0ebe6bfa213c5472" datatype="html">
+        <source>Opinion of operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+        <note priority="1" from="description">Label for the opinion of operator field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f066e1eb28d8ae8a8877b138277b4c05e1c0c226" datatype="html">
+        <source>Litigation status</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+        <note priority="1" from="description">Label for the litigation status field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="b4a2de6607352730a6af5fcb59263e27439f2c5a" datatype="html">
+        <source>Monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">107</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <note priority="1" from="description">Label for the monitor field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="ffeb07b7af4b3905ed99ac72ad636ca63bc05dc8" datatype="html">
+        <source>Please select a monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">105</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the monitor isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="dd2f34de17cff8207d4e0ec104bc093faac2b8eb" datatype="html">
+        <source>Operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">115</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <note priority="1" from="description">Label for the operator field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c70b9e0c5e8e83b7427e178e4f95ab6559c43224" datatype="html">
+        <source>Please select an operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">113</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the operator isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="711d402d0117e5b0abb02c988648b9c41ea13975" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">123</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">117</context>
+        </context-group>
+        <note priority="1" from="description">Label for the active field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c324d1ec6ff085cd19e6bce739b05ad9475e0672" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">122</context>
+        </context-group>
+        <note priority="1" from="description">Label for the details field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="7e9e4e7c021c606a03a4cd3f5b9331bd37fb109d" datatype="html">
+        <source>Evidence</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">133</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
+        <note priority="1" from="description">Label for the evidence field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="536f971e3d6c6ed722df6f46081168ddd2d2aa5d" datatype="html">
+        <source>
+      New governance sub-category
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a governance sub-category</note>
+      </trans-unit>
+      <trans-unit id="f59e607fb08307278ff4d632a8403cc7250f40b7" datatype="html">
+        <source>Governance Pillar</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the governance pillar of the governance sub-categories</note>
+        <note priority="1" from="meaning">Table of governance sub-categories</note>
+      </trans-unit>
+      <trans-unit id="646cbe17a5d08e57cb34928dfe7fa7cd23481ce0" datatype="html">
+        <source>Governance Problem</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the governance problem of the governance sub-categories</note>
+        <note priority="1" from="meaning">Table of governance sub-categories</note>
+      </trans-unit>
+      <trans-unit id="f5f4971be2896724f7402e018c02e4998d0f7165" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of governance sub-categories</note>
+      </trans-unit>
+      <trans-unit id="7d29efb5dea57b061811390c578b3c386ac28802" datatype="html">
+        <source>Sub-categories (Governance)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the governance sub-categories</note>
+      </trans-unit>
+      <trans-unit id="9c16ee275da84e3a95d9ee5f7bb01a42ef3df5b2" datatype="html">
+        <source>New governance sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Governance sub-category creation</note>
+      </trans-unit>
+      <trans-unit id="7891175220c7fe8e6e94d10cf7726ede071792fc" datatype="html">
+        <source>Update governance sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Governance sub-category edition</note>
+      </trans-unit>
+      <trans-unit id="70a67e04629f6d412db0a12d51820b480788d795" datatype="html">
+        <source>Create</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">136</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">142</context>
+        </context-group>
+        <note priority="1" from="description">Create button</note>
+      </trans-unit>
+      <trans-unit id="6909f80c54d37a94153b18d639d4dbf990634bf7" datatype="html">
+        <source>Governance pillar</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the governance pillar field</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6ed681ff2468c607172396fc02a073dac8b4efaf" datatype="html">
+        <source>Governance pillar is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the governance pillar isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="a7dc4236b38404ed8d4aa4c9fb780ccc040ccd9e" datatype="html">
+        <source>Governance problem</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <note priority="1" from="description">Label for the governance problem field</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="54b7e1b3b75e6445b2f2e6784cb3be46286ea10d" datatype="html">
+        <source>Governance problem is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the governance problem isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c277d5768b2a4c5b1925b6c0dc7ec58ae1bc1d05" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Label for the details field</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="609e416695033263472042503c888c0461e7bf99" datatype="html">
+        <source>
+      New operator sub-category
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a operator sub-category</note>
+      </trans-unit>
+      <trans-unit id="400ca8ca7107a0d8e8929b04d8fc4c185d183f1b" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the operator sub-categories</note>
+        <note priority="1" from="meaning">Table of operator sub-categories</note>
+      </trans-unit>
+      <trans-unit id="31f4b66a2ffe7471f4f39930204bc4f382f5dfd3" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the detail of the operator sub-categories</note>
+        <note priority="1" from="meaning">Table of operator sub-categories</note>
+      </trans-unit>
+      <trans-unit id="f63250c4baab4b9281bc0babcc6ff86338771d19" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of operator sub-categories</note>
+      </trans-unit>
+      <trans-unit id="01913c9d313d04a592d6aa364ad1e8b13717cd42" datatype="html">
+        <source>Sub-categories (Operators)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the operator sub-categories</note>
+      </trans-unit>
+      <trans-unit id="1da555b26e38aea784e23a1092afa8ba60693dbb" datatype="html">
+        <source>New operator sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Operator sub-category creation</note>
+      </trans-unit>
+      <trans-unit id="773e146f4baed993f7e61607302504f702ebef35" datatype="html">
+        <source>Update operator sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Operator sub-category edition</note>
+      </trans-unit>
+      <trans-unit id="8e29884856ab62e66baed2206fe9f251c542932e" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="cf8f4120bf44e9a770d8d4ec2cf0f68c2db7f24e" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="e5ed666f8f6a2589cd3c7979b243e5bc6f78d60d" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1ca5483adf9af728d5d0a98cd364a694cc422e63" datatype="html">
+        <source>Law references</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Label for the law references field</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="0a6091f7c64135d8ec9439019908e8f1e6d28d6b" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <note priority="1" from="description">Label for the details field</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="85afe36487fab2e70904c3d796f0ea2f7a5a90a9" datatype="html">
+        <source>New category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Category creation</note>
+      </trans-unit>
+      <trans-unit id="c9315cc027fda44df7772e7fa05aa74402dc017d" datatype="html">
+        <source>Update category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Category edition</note>
+      </trans-unit>
+      <trans-unit id="48df2497540119700a2d0e0f26d629c837fd7fc6" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2637b135fb7dc9dab5d9b2cd507716b80cb98240" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="d3392cb23bca77d1014e89b5e8aefcfb4ccad87b" datatype="html">
+        <source>
+      New Operator
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new operator</note>
+      </trans-unit>
+      <trans-unit id="801e19d7c8bfcbcc9ede4749d1885f45759b8c8b" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the operators</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="60a3c060cf7bbe40ffbfc35b0b3bb691a789a4e7" datatype="html">
+        <source>Type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the type of the operators</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="4f00329eba86dfea8ce882af55cbe475c00c1036" datatype="html">
+        <source>Concession</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the concession of the operators</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="b029eee35172b814101cf828fb5f9a61e1391c0f" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the whether or not the operators are active</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="39ffe1e95aa519b9645e62af04ed0a3cfa032b42" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
+        <source>Operators</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the operators</note>
+      </trans-unit>
+      <trans-unit id="1dbd4bf0057e786321c83ca35a3c4e2b77f181a9" datatype="html">
+        <source>New operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Operator creation</note>
+      </trans-unit>
+      <trans-unit id="f0a8d16cabce095b3508ff9dbeb0459b33249e5d" datatype="html">
+        <source>Update operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Operator creation</note>
+      </trans-unit>
+      <trans-unit id="9fd38b8fcd5e17ff3611d046ce724e16a2000109" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="77728cbe1d84a03b45077d0bcdb10f2ccbeb223e" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f152c650bc08e63a3b7a2471c3ef3ab62cf3d52b" datatype="html">
+        <source>Operator type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the operator type field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2a0e9f550a391aa5b4639d2c85ba060358390726" datatype="html">
+        <source>Logging</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="6ef0619a37140118b9e640c6cc36ee4e9fb4372a" datatype="html">
+        <source>Company</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="99186438c83c4c7e8b9cc78dfa43f7fd524b5e6e" datatype="html">
+        <source>Artisanal</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="0ad4531bb4bd5e0c7770dfdd89a99befcad6c8ea" datatype="html">
+        <source>Sawmill</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="f5a5b7fe27eecc145ce874a267d55abd47590494" datatype="html">
+        <source>Community Forest</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="e856ab987b69555ee8e5f8cd7e442de3eabea7f4" datatype="html">
+        <source>ARB1327</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="33cf379d245d5fb087711431420fb0ef6ed3e43b" datatype="html">
+        <source>Palm Oil</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="5d79e032a7657d92b56373c5cc20d0724ef9c73a" datatype="html">
+        <source>Trader</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="cafbab33e33e79a58b4eefad43938b99d0426314" datatype="html">
+        <source>Please select an operator type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the operator type isn&apos;t supplied (the user will have to choose between several options)</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="fe69558920c9d7980d3f3acf5c1ac18191b180d9" datatype="html">
+        <source>
+      <x id="START_TAG_LABEL" ctype="x-label"/>Country<x id="CLOSE_TAG_LABEL" ctype="x-label"/>
+      <x id="START_TAG_SELECT" ctype="x-select"/>
+        <x id="START_TAG_OPTION" ctype="x-option"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_OPTION" ctype="x-option"/>
+      <x id="CLOSE_TAG_SELECT" ctype="x-select"/>
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="8c88e1c3c79928abc132f9da3d38a81a8511fa0a" datatype="html">
+        <source>Concession</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <note priority="1" from="description">Label for the concession field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="3934c8285a2371995bd611a986efcbfa9253b8e2" datatype="html">
+        <source>Country centroid</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country centroid field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1e033c6c092d12800660484eec7a772925639eb6" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+        <note priority="1" from="description">Label for the field to tell whether the operator is active or not</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2f4c185a5507bc6ff049778effdc2ca682aab774" datatype="html">
+        <source>
+      New Country
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new country</note>
+      </trans-unit>
+      <trans-unit id="de0beb4f2c7b3619f47224ad8a5feedb860dfc0c" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the countries</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="b9d28a4b3787fdb725362102e55e54541497723c" datatype="html">
+        <source>ISO</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the ISO code of the countries</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="902f1ade07cad3f447858b17c2da63e8f7e26ce8" datatype="html">
+        <source>Region Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the region name of the countries</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="6bb7c94296bdb62165caa3ed3e9151390c0811f9" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to whether or not the countries are active</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="ab07255a444e77bef3e19ddaca4b72a1c8eb360e" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="aee7d0de4e30405c1289745e4264e622b613632a" datatype="html">
+        <source>Countries</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the countries</note>
+      </trans-unit>
+      <trans-unit id="e4a0e02a470737d8053a8ced70e98d1978442484" datatype="html">
+        <source>New country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Country creation</note>
+      </trans-unit>
+      <trans-unit id="c9eed87bc1809a6190cb533f6e034c8c240721ea" datatype="html">
+        <source>Update country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Country edition</note>
+      </trans-unit>
+      <trans-unit id="f9a075ede38c8f0b8e1ebc8a636ff9c2e1d2d5ac" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="7772f40a6bf4492246a964933bcd562d63690558" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="fa04f51e70170a51b8409850619f58194170bf81" datatype="html">
+        <source>Region name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the region name field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="5620a84efc9854a3c1c04b51762b8c12ff7ba334" datatype="html">
+        <source>ISO</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Label for the ISO code field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="85c0d8144b112baf450f3265187ed54f3cedb65a" datatype="html">
+        <source>ISO is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the ISO code isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2808eef1afd0850f3fc4d5bb4af9c8d760a83537" datatype="html">
+        <source>Region ISO</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">Label for the region ISO code field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f4ba7b2b4ecc25e0b57747d4cc613996662cb0c4" datatype="html">
+        <source>Country centroid</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country centroid field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6dc87818baaf0762c2e63182ecbf55ef11907b2a" datatype="html">
+        <source>Region centroid</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <note priority="1" from="description">Label for the region centroid field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="8a1e8e453f1ca7b66f462780f073fd214fd7a012" datatype="html">
+        <source>Available for observations?</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <note priority="1" from="description">Label for the field that let the user select if the country will be available for observations</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="ca902a857f64589071e0712f19210e799ee0fba4" datatype="html">
+        <source>
+      New species
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new species</note>
+      </trans-unit>
+      <trans-unit id="7d1762ee4d496a6c991fde6dcfbec7af4144c1cc" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the species</note>
+        <note priority="1" from="meaning">Table of species</note>
+      </trans-unit>
+      <trans-unit id="79c4cd49d2cd2f84007b9e115400686f56986a1e" datatype="html">
+        <source>Species class</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the species class of the species</note>
+        <note priority="1" from="meaning">Table of species</note>
+      </trans-unit>
+      <trans-unit id="c7703ff5d60e6ef26ff13b44cbb0265e145a1888" datatype="html">
+        <source>Scientific name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the scientific name of the species</note>
+        <note priority="1" from="meaning">Table of species</note>
+      </trans-unit>
+      <trans-unit id="6a5cd6a6798a329a413178bdbbbe22c5edd66d89" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of species</note>
+      </trans-unit>
+      <trans-unit id="ec2b122ed8617f51ed128267a65711e40e56b5bc" datatype="html">
+        <source>Species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the species</note>
+      </trans-unit>
+      <trans-unit id="eb53d60e9bf9ae875707a6941231e2a21c7f1120" datatype="html">
+        <source>
+      New Monitor
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new monitor</note>
+      </trans-unit>
+      <trans-unit id="ebe3ca55e2a451ca15ee5d9b7310f0377b6e2b0e" datatype="html">
+        <source>Date</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the date of the monitors</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="c818c652325d319c5fa88875471f20eb663a12b3" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the monitors</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="b2ef1717958c380c23c8921591715b7fbaf91cb8" datatype="html">
+        <source>Type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the type of monitors</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="b1d9f070c335abb9c7877c5effde44fc31d7346c" datatype="html">
+        <source>Organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the organizations of the monitors</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="b4237c13c658454f4a55897e4a3cf73c30a80e0e" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the whether the monitors are active or not</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="53e3ce2b1d00ae0c8f1f2d8cabbab9cfd91c67ff" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="258847bc2f56543f10b58ce2f85c72994567bcb6" datatype="html">
+        <source>
+      New law
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new law</note>
+      </trans-unit>
+      <trans-unit id="67572ae9cc69d32f40b3259490b91cecc3f5f85d" datatype="html">
+        <source>Legal Reference</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the legal reference of the laws</note>
+        <note priority="1" from="meaning">Table of laws</note>
+      </trans-unit>
+      <trans-unit id="94380867a6d2b9b39396e6754e7d10d8ebe9085e" datatype="html">
+        <source>Legal Penalty</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the legal penalty of the laws</note>
+        <note priority="1" from="meaning">Table of laws</note>
+      </trans-unit>
+      <trans-unit id="8070d4dfa7c8357d6d5ce2b1f920d6d584dc9cdc" datatype="html">
+        <source>VPA indicator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the VPA indicator of the laws</note>
+        <note priority="1" from="meaning">Table of laws</note>
+      </trans-unit>
+      <trans-unit id="0610fd99f9f9b25f432fb2bd65249748420efc70" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of laws</note>
+      </trans-unit>
+      <trans-unit id="d9f85cde7086ccd4c97fc1ae6e656dd68db51d4b" datatype="html">
+        <source>Laws</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the laws</note>
+      </trans-unit>
+      <trans-unit id="ebc02487572b7b91efac0f364a963de1836fc422" datatype="html">
+        <source>New species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Species creation</note>
+      </trans-unit>
+      <trans-unit id="4e20ed317e78bb9276d249261909b0dd7b89fdbe" datatype="html">
+        <source>Update species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Species edition</note>
+      </trans-unit>
+      <trans-unit id="9450101fd324b122e3c2eebe39ea1efb73ed835a" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6e79c544a6f881f3b2bc6c311136b1b07e61db80" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6513c8fc3343f39e6523ebcb32977f7fd74a6042" datatype="html">
+        <source>Common name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Label for the common name field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="dd0a5f500aef0ecaac829d038616a1c561b644e7" datatype="html">
+        <source>Scientific name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Label for the scientific name field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2cbd3b29e44968bc1915613d5cd3e31b41237adb" datatype="html">
+        <source>Species class</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">Label for the species class field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="53f592247ce5bd687d87c9e07f6d9eed9d30da20" datatype="html">
+        <source>Sub species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <note priority="1" from="description">Label for the sub species field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="20b6a2bdb411d5ee55c944816a0632c5f4ce8917" datatype="html">
+        <source>Species family</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <note priority="1" from="description">Label for the species family field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f2203853494dd5e56d65f8ec663b0a9c5d627b55" datatype="html">
+        <source>Kingdom</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <note priority="1" from="description">Label for the kingdom field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="d1cd8111b4fe023923f890c0a7c44cc94cada286" datatype="html">
+        <source>CITES status</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <note priority="1" from="description">Label for the CITES status field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1f823441a94afdbe8a76e2677645c4dee6bdb3b3" datatype="html">
+        <source>IUCN status</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <note priority="1" from="description">Label for the IUCN status field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f7b77c07f0f64b0f4946d066ccb7caf42f6d64f5" datatype="html">
+        <source>New monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Monitor creation</note>
+      </trans-unit>
+      <trans-unit id="d37e644a3c2fe4a97af5fc04c5ba23c50ca0d1bc" datatype="html">
+        <source>Update monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Monitor edition</note>
+      </trans-unit>
+      <trans-unit id="970d6446f3e343408a02266007c4782e5ffc18e2" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2f23d7732da6de204b25e720af0932539533f290" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f09fef617d6a9de0ef89d7e9a9582ebe111dd27e" datatype="html">
+        <source>Monitor type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Label for the monitor type field</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="72638e600ce222ed8184c47260bbd68d362e693e" datatype="html">
+        <source>External</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Type of monitor</note>
+      </trans-unit>
+      <trans-unit id="59d614de306c59782f5daa000ac64ab78986dfe3" datatype="html">
+        <source>Government</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Type of monitor</note>
+      </trans-unit>
+      <trans-unit id="f92e4776a0e55bc1f62e42a33492a06fcf1ef6f4" datatype="html">
+        <source>Please select a type of monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the monitor type isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="56e1213f23dc45ca22b840ca175d09878c2fa327" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c474aac05e8433059be3ef9df630c75d919d91f0" datatype="html">
+        <source>Organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <note priority="1" from="description">Label for the organization&apos;s name field</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2423329875b86c153e867d7b73ca084967a5ca4d" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <note priority="1" from="description">Label for the field to tell whether the monitor is active or not</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="902d8c9a37cd5dbfbf804818d51018f57ee5ff6f" datatype="html">
+        <source>New law</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Law creation</note>
+      </trans-unit>
+      <trans-unit id="f936a2051fc16836b5957df80ea4daf45dac6fb4" datatype="html">
+        <source>Update law</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Law edition</note>
+      </trans-unit>
+      <trans-unit id="4ed0d6f64ddd3927b180003fed3cfec68eeca9fc" datatype="html">
+        <source>Legal reference</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the legal reference field</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1f5821b1de3e5287dd47d5afd1c73e8481f334a4" datatype="html">
+        <source>Legal reference is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the legal reference isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="5dee6b0be929a8b581a7d1e1dadb99163583707d" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="5909daed5b4040739fd19794fc9eb601db3840f7" datatype="html">
+        <source>Please select a country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="0ba722b8181589f48f6982c2e6289a3a7e638b30" datatype="html">
+        <source>VPA indicator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Label for the VPA indicator field</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="da81d170cec9c56d085e1a83d72a75083fb34bde" datatype="html">
+        <source>Legal penalty</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">Label for the legal penalty field</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="da0e191e3b5ce9a03ebf6935c7a3da8f1df39963" datatype="html">
+        <source>New government</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Government creation</note>
+      </trans-unit>
+      <trans-unit id="d63b452dfa4a1be6a31c188edf56b946a9bc3a36" datatype="html">
+        <source>Update government</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Government creation</note>
+      </trans-unit>
+      <trans-unit id="994f851a27e09e9b2eb725f832cc0d6406362b63" datatype="html">
+        <source>Government entity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the government entity field</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="d3a14f1a9f2eccb2b150c1a53d36ff3642f41664" datatype="html">
+        <source>Government entity is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the government entity isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="0b577ea470cf9239b9ee5a7f49e1648b38450413" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f2fae309178d62c60d650f78ee2f5076fc48cb02" datatype="html">
+        <source>Please select a country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to choose between serveral options)</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="070870f728185c5169acfbd58382939274fcbc27" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Label for the details field</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="263deacc741fd6429b2a1fd3719ded604f0799d0" datatype="html">
+        <source>
+      New government unit
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new government unit</note>
+      </trans-unit>
+      <trans-unit id="7375730a696290da1ac4a1b41aa1807227704d38" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the governments</note>
+        <note priority="1" from="meaning">Table of governments</note>
+      </trans-unit>
+      <trans-unit id="a77615221336090843bf4217630174cf0aaadcb2" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the details of the governments</note>
+        <note priority="1" from="meaning">Table of governments</note>
+      </trans-unit>
+      <trans-unit id="77d0d5ee531ac0867be1b0ce429d9f23314fa4cd" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of governments</note>
+      </trans-unit>
+      <trans-unit id="648fe89999cc59abebc2ff5e62c7f4f619bf456e" datatype="html">
+        <source>Governments</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the governments</note>
+      </trans-unit>
+      <trans-unit id="bf0b87b1211a6459b83e5f3774a659e5d2e77b9f" datatype="html">
+        <source>
+      New Category
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new category</note>
+      </trans-unit>
+      <trans-unit id="3e44dbcc81d17832a393250e494929e0b6382c0b" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the categories</note>
+        <note priority="1" from="meaning">Table of categories</note>
+      </trans-unit>
+      <trans-unit id="a0d9d59763903ebae40d4d8e3b62ffbf5d3d717a" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of categories</note>
+      </trans-unit>
+      <trans-unit id="04201f9d27abd7d6f58a4328ab98063ce1072006" datatype="html">
+        <source>Categories</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the categories</note>
+      </trans-unit>
+      <trans-unit id="daf4f4c015509bb67eb6d6d726b256a8615d7758" datatype="html">
+        <source>Open Timber Portal</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Name of the app</note>
+      </trans-unit>
+      <trans-unit id="3fdc751b264ca9998e1542fcf5794e274cd56344" datatype="html">
+        <source>Log out</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Log out button</note>
+      </trans-unit>
+      <trans-unit id="1ae1df848c628a7a059c1ff57be3449ecacc5c91" datatype="html">
+        <source>New user</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">User creation</note>
+      </trans-unit>
+      <trans-unit id="7663160100ebcc9a117c8cb206b0624e172f89c9" datatype="html">
+        <source>Update user</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">User edition</note>
+      </trans-unit>
+      <trans-unit id="4b43d07d0171b690cd5d541d649389af16378912" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field (name of the person)</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="a8077802820f0bac578cee128f3146719d87c292" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="9531f868dd03aac6f0d2687eed93dd57d4fcb910" datatype="html">
+        <source>Username</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Label for the username field (a nickname)</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="517d85ca7650f90dd91f14a4e3ecffab28967926" datatype="html">
+        <source>Username is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the username/nickname isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="62dc5076c0fe3427ba6a0ed17008cecea393c1a1" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">Label for the email field</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6c46fe594e7a68965a97b78ef5e22859e5781d68" datatype="html">
+        <source>Email is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="ad967d9088a765aebf92c3116b8f5398d6e2de09" datatype="html">
+        <source>Please enter an email address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="9515b8c96b948fff69c74667be3248115e876ed2" datatype="html">
+        <source>Institution</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <note priority="1" from="description">Label for the institution field (name of the insitution, organization)</note>
+        <note priority="1" from="meaning">User creation</note>
+      </trans-unit>
+      <trans-unit id="e9959215c7e71edde620b01439f5ffbecd5d2b27" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="4fe21c99a9c7a18ae378c3e0958b146f21e56ad9" datatype="html">
+        <source>Password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password field</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="795dfb8a206622b513661b3ecdb0e697e4cd1e0f" datatype="html">
+        <source>Password is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="0decdfdf829ae2fdedebac57ce24f1cbdca085fb" datatype="html">
+        <source>Confirm your password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password confirmation field</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="8c0add49e7d050ab76f5f1bf53b43410f95d73bb" datatype="html">
+        <source>Please confirm your password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password confirmation isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="03a6fc721e7fcdae64bb5982a0674ca3c45d1870" datatype="html">
+        <source>Password values don&apos;t not coincide</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password and its confirmation don&apos;t coincide&apos;</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="d0003e833df402846f87694894de69a744609fcb" datatype="html">
+        <source>Permissions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <note priority="1" from="description">Label for the permissions field (the user will have to choose a role)</note>
+        <note priority="1" from="meaning">User creation</note>
+      </trans-unit>
+      <trans-unit id="408cb6073e60c5d966296a3207fc596adca75e01" datatype="html">
+        <source>Admin</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <note priority="1" from="description">User role</note>
+      </trans-unit>
+      <trans-unit id="e652540fcb10505228ef38a3a9790a94a3728fc5" datatype="html">
+        <source>NGO</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <note priority="1" from="description">User role</note>
+      </trans-unit>
+      <trans-unit id="f3dba5732cb548f04fc8b4727e3568f5169956f1" datatype="html">
+        <source>New observation</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Observation creation</note>
+      </trans-unit>
+      <trans-unit id="a01fcf88689d79ed060dce1f72b5adeaa7b46faf" datatype="html">
+        <source>Please select a observation type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the type isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1a6f616703d75ae22ef5f11706c3815ca04888c5" datatype="html">
+        <source>
+        New user
+      </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new user</note>
+      </trans-unit>
+      <trans-unit id="408d18faf367209fe427e59b979f2b44901e0e7c" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the users</note>
+        <note priority="1" from="meaning">Table of users</note>
+      </trans-unit>
+      <trans-unit id="0a15a5d859d810d87d241e8c1e0320a6bf4eaab6" datatype="html">
+        <source>Username</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the username/nickname of the users</note>
+        <note priority="1" from="meaning">Table of users</note>
+      </trans-unit>
+      <trans-unit id="d9a3cb1133a129319296a62a6592ccb4633c37ad" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the email of the users</note>
+        <note priority="1" from="meaning">Table of users</note>
+      </trans-unit>
+      <trans-unit id="7ed96443291c57e0eef0a6f1adcbf1a3013449a4" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of users</note>
+      </trans-unit>
+      <trans-unit id="4d13a9cd5ed3dcee0eab22cb25198d43886942be" datatype="html">
+        <source>Users</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the users</note>
+      </trans-unit>
+      <trans-unit id="30e10cd5f105624805db7f96287a3b7edd5fff9c" datatype="html">
+        <source>My OTP</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <note priority="1" from="description">My OTP menu option</note>
+      </trans-unit>
+      <trans-unit id="4b8c7b2a240e413c2c1eb4a69abf371ac5c5742e" datatype="html">
+        <source>Observations</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Observations menu option</note>
+      </trans-unit>
+      <trans-unit id="faf74edc4404313eeb85945cc1a99cc4ff4a6fd6" datatype="html">
+        <source>Fields</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Fields menu option</note>
+      </trans-unit>
+      <trans-unit id="099668cc93fe681254739694dc7d662069a8b659" datatype="html">
+        <source>Register</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="245198374604dd2866e843ca1411b3b5bee26b4b" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field (name of the person)</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="455490d6079d0287a4dd8a51d0087c7df48e018c" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="077471e569722451975586da916fe91f1eede0f0" datatype="html">
+        <source>Username</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Label for the username field (a nickname)</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="89434c6c32783ce50a9818d919b0cfcf1883dfe7" datatype="html">
+        <source>Username is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the username/nickname isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="67e26ffa056d34f8f5c34cfe01af731f4667d420" datatype="html">
+        <source>Institution</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the institution field (name of the insitution, organization)</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="ff8c80b065ad5802b5d2539e41ec7bfa14c65646" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="0e420cff0712db35b0fb636b9c7b73182307ee48" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Label for the email field</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="e3e6b8f98dd44b6c1cb5834713b771004b15369a" datatype="html">
+        <source>Email is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="0852bccb9acdfc7c24ea9f89f997812e20c5f66c" datatype="html">
+        <source>Please enter an email address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="8878633ec07d9bfe29eaf51cf501e87fe3df588f" datatype="html">
+        <source>Password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password field</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="37259b13dc58cf4ece14d58b0e3c3dc883105168" datatype="html">
+        <source>Password is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="87d9a4f470c63e0b8bfe7279223532e87adf6f08" datatype="html">
+        <source>Confirm your password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password confirmation field</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="a6f6372f4dd465f68c31293774b454b477bdc918" datatype="html">
+        <source>Please confirm your password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password confirmation isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="c45bce7d5bebd3886fa2ec661b234da55c062f54" datatype="html">
+        <source>Password values don&apos;t not coincide</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password and it&apos;s confirmation don&apos;t coincide</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="6765b4c916060f6bc42d9bb69e80377dbcb5e4e9" datatype="html">
+        <source>Login</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Button to log in</note>
+      </trans-unit>
+      <trans-unit id="cfc2f436ec2beffb042e7511a73c89c372e86a6c" datatype="html">
+        <source>Register</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Button to register</note>
+      </trans-unit>
+      <trans-unit id="229210ea5aded39aacf9e7d79e1658b32ca104f6" datatype="html">
+        <source>New observation</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new observation</note>
+      </trans-unit>
+      <trans-unit id="00c200adab3e41e35d1e06d42d847d17f747e71c" datatype="html">
+        <source>Date</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the date of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="645872c938ac5195a4906afa0f6118cc9b52771b" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the country of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="0ea6d0e3424fa1ffdb64a3b98a9815c98b595435" datatype="html">
+        <source>Operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the operator name of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="be0139f1cf8e5feab4a5b691287c7c0d9c74fc86" datatype="html">
+        <source>Category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the category of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="788391ad82018522ef4162b47fb8e81f00217bd6" datatype="html">
+        <source>Observation</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the details of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="a8a36702a876525737fdbabb99b6f5bceac167a6" datatype="html">
+        <source>Severity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the severity of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="f988c370ec8c750c0b84a0c412e440d53cee631d" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="8d68caf60e263e599e86d21321e1939323492821" datatype="html">
+        <source>Login</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="4d8a562e319cebae08fb094877d11d80be7ed87d" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Label for the email field</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="4c7f617fdaf91a9d45c52aa985e99304538bf140" datatype="html">
+        <source>Email is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="dec04191c54f62c23d2012fafcb24c07c198ba58" datatype="html">
+        <source>Please enter an email address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="69a2b7b2e465e58e7df02173034ee5f9c332ad70" datatype="html">
+        <source>Password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password field</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="ee6940c10dba8bb8734ddb805ccc75c02f0ace8b" datatype="html">
+        <source>Password is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Login page</note>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file source-language="en" datatype="plaintext" original="ng2.template">
+  <file source-language="en" datatype="plaintext" original="ng2.template" target-language="en">
     <body>
       <trans-unit id="4f7091778907548985c8b4a592fa68e0f4c3368e" datatype="html">
         <source>404. Page not found</source>
-        <target/>
+        <target state="final">404. Page not found</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="7b899c5c53c6d77238cbc42d49e17dcac27ba085" datatype="html">
         <source>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</source>
-        <target/>
+        <target state="final">The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -24,17 +24,17 @@
       </trans-unit>
       <trans-unit id="7fb2c801d64dddc6287ab33765a74490ff471cc3" datatype="html">
         <source>Go to my OTP</source>
-        <target/>
+        <target state="final">Go to my OTP</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">5</context>
         </context-group>
-        <note priority="1" from="description">Button to suggest the user to go to the &apos;My OTP&apos; page</note>
+        <note priority="1" from="description">Button to suggest the user to go to the 'My OTP' page</note>
         <note priority="1" from="meaning">404 page</note>
       </trans-unit>
       <trans-unit id="e32a02d7bc279823ef3a51428092c600cc181612" datatype="html">
         <source>Go to login page</source>
-        <target/>
+        <target state="final">Go to login page</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="bebaee9b83b435336940bd0f6bbecbefb8b81470" datatype="html">
         <source>Undefined table</source>
-        <target/>
+        <target state="final">Undefined table</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -53,7 +53,7 @@
       </trans-unit>
       <trans-unit id="5a97a400bac7feaf727c8bf556aaef97e34d82ea" datatype="html">
         <source>, sorted by</source>
-        <target/>
+        <target state="final">, sorted by</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">8</context>
@@ -62,7 +62,7 @@
       </trans-unit>
       <trans-unit id="6e0fa4af5418a615a1a09c67e32682e6b69c0f79" datatype="html">
         <source>ascendent</source>
-        <target/>
+        <target state="final">ascendent</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">8</context>
@@ -71,7 +71,7 @@
       </trans-unit>
       <trans-unit id="547d6a7a6de920a2aefc34eeec1b9fc3d393bbb8" datatype="html">
         <source>descendent</source>
-        <target/>
+        <target state="final">descendent</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">8</context>
@@ -80,7 +80,7 @@
       </trans-unit>
       <trans-unit id="6219cbb729e72ee75b30c2ce46d7959d1d09aa8d" datatype="html">
         <source>Page</source>
-        <target/>
+        <target state="final">Page</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">48</context>
@@ -90,7 +90,7 @@
       </trans-unit>
       <trans-unit id="e3706b34167ca5b613defa8be3a5d4c6316741e5" datatype="html">
         <source>Previous</source>
-        <target/>
+        <target state="final">Previous</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">51</context>
@@ -100,7 +100,7 @@
       </trans-unit>
       <trans-unit id="274039dd3b5e706302cf2c3c433ea450bdd49703" datatype="html">
         <source>Next</source>
-        <target/>
+        <target state="final">Next</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">61</context>
@@ -110,7 +110,7 @@
       </trans-unit>
       <trans-unit id="65701e62f4eb6566c62a6088842f6f95fa8ef48e" datatype="html">
         <source>Organization profile</source>
-        <target/>
+        <target state="final">Organization profile</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -119,12 +119,12 @@
           <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
           <context context-type="linenumber">11</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;My OTP&apos; page</note>
+        <note priority="1" from="description">Menu located on the 'My OTP' page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="fb32420414820f45d127a9e6f51985800d930fbb" datatype="html">
         <source>My observations</source>
-        <target/>
+        <target state="final">My observations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -133,12 +133,12 @@
           <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
           <context context-type="linenumber">12</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;My OTP&apos; page</note>
+        <note priority="1" from="description">Menu located on the 'My OTP' page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="fa9b7116761f013fe509c7646dee9d1e9c3cc31a" datatype="html">
         <source>Name of the organization</source>
-        <target/>
+        <target state="final">Name of the organization</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">7</context>
@@ -148,7 +148,7 @@
       </trans-unit>
       <trans-unit id="d5035c69fba58edb578fe982eb8a03175f494319" datatype="html">
         <source>Name is required</source>
-        <target/>
+        <target state="final">Name is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -161,12 +161,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">54</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name of the organization isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the name of the organization isn't supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="43ecccfbfb54901f26ce0d24939dbfff4315e553" datatype="html">
         <source>Address</source>
-        <target/>
+        <target state="final">Address</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -176,17 +176,17 @@
       </trans-unit>
       <trans-unit id="5aa48f8e4b18078364f9fa7af5fd13b8a4ade535" datatype="html">
         <source>Address is required</source>
-        <target/>
+        <target state="final">Address is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">15</context>
         </context-group>
-        <note priority="1" from="description">Error message if the address isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the address isn't supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="7a19016a7b3167d2713f39b788e5e7d80f3f737d" datatype="html">
         <source>Contact information (General information)</source>
-        <target/>
+        <target state="final">Contact information (General information)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">19</context>
@@ -196,7 +196,7 @@
       </trans-unit>
       <trans-unit id="1bb6270fc515c0526e262c35cf24ba9cf34bf917" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">24</context>
@@ -205,12 +205,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">52</context>
         </context-group>
-        <note priority="1" from="description">Label for the contact&apos;s name field (general information)</note>
+        <note priority="1" from="description">Label for the contact's name field (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="caff929db9ef4d149aee1cc57926540ee74b88db" datatype="html">
         <source>Email</source>
-        <target/>
+        <target state="final">Email</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">30</context>
@@ -219,12 +219,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">58</context>
         </context-group>
-        <note priority="1" from="description">Label for the contact&apos;s email field (general information)</note>
+        <note priority="1" from="description">Label for the contact's email field (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="d642a03eb15d9e04e7577d51323276179b7324e2" datatype="html">
         <source>Email is required</source>
-        <target/>
+        <target state="final">Email is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">32</context>
@@ -233,12 +233,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">60</context>
         </context-group>
-        <note priority="1" from="description">Error message if the contact email isn&apos;t supplied (general information)</note>
+        <note priority="1" from="description">Error message if the contact email isn't supplied (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="f5de8925e983f8662cf13f3f03d94643ba8eee8c" datatype="html">
         <source>Please enter an email address</source>
-        <target/>
+        <target state="final">Please enter an email address</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -247,12 +247,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">61</context>
         </context-group>
-        <note priority="1" from="description">Error message if the contact email isn&apos;t valid (general information)</note>
+        <note priority="1" from="description">Error message if the contact email isn't valid (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="ddabada26b82beaa67cb0b3fdcf54a282921afe1" datatype="html">
         <source>Phone number</source>
-        <target/>
+        <target state="final">Phone number</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -261,12 +261,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">65</context>
         </context-group>
-        <note priority="1" from="description">Label for the contact&apos;s phone number field (general information)</note>
+        <note priority="1" from="description">Label for the contact's phone number field (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="178268700e3527de634d28f7e397b10a5cecd7a0" datatype="html">
         <source>Phone number is required</source>
-        <target/>
+        <target state="final">Phone number is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">39</context>
@@ -275,12 +275,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">67</context>
         </context-group>
-        <note priority="1" from="description">Error message if the contact phone number isn&apos;t supplied (general information)</note>
+        <note priority="1" from="description">Error message if the contact phone number isn't supplied (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="15681d9d8184e095004288f60aace675ddc8e930" datatype="html">
         <source>Contact information (For inquiries on data uploaded)</source>
-        <target/>
+        <target state="final">Contact information (For inquiries on data uploaded)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">47</context>
@@ -290,7 +290,7 @@
       </trans-unit>
       <trans-unit id="8056edf01468679e6f762fece7279fd0a31c0474" datatype="html">
         <source>Type of organization</source>
-        <target/>
+        <target state="final">Type of organization</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">75</context>
@@ -300,7 +300,7 @@
       </trans-unit>
       <trans-unit id="286a22f1d01b750cc5f9fe1fc0053494c4fb9411" datatype="html">
         <source>Non governmental organization (NGO)</source>
-        <target/>
+        <target state="final">Non governmental organization (NGO)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">77</context>
@@ -309,7 +309,7 @@
       </trans-unit>
       <trans-unit id="8ae0be16277ef1c4b8c160c21c709addaafdf4b7" datatype="html">
         <source>Academic</source>
-        <target/>
+        <target state="final">Academic</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">78</context>
@@ -318,7 +318,7 @@
       </trans-unit>
       <trans-unit id="6de33973fba79ddbbc39cf39c100d1818d363ab1" datatype="html">
         <source>Research Institute</source>
-        <target/>
+        <target state="final">Research Institute</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">79</context>
@@ -327,7 +327,7 @@
       </trans-unit>
       <trans-unit id="9afb9078f854a9c32cdf55d49309ef19b5b6338d" datatype="html">
         <source>Private company</source>
-        <target/>
+        <target state="final">Private company</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">80</context>
@@ -336,7 +336,7 @@
       </trans-unit>
       <trans-unit id="c2a9de3714f5767b174d0424bc8abe2dc37acc41" datatype="html">
         <source>Other</source>
-        <target/>
+        <target state="final">Other</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">81</context>
@@ -349,17 +349,17 @@
       </trans-unit>
       <trans-unit id="77ddb384bda36384bf19fd82da34668638cd1237" datatype="html">
         <source>Please select a type of organization</source>
-        <target/>
+        <target state="final">Please select a type of organization</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">83</context>
         </context-group>
-        <note priority="1" from="description">Error message if the type of organization isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="description">Error message if the type of organization isn't supplied (the user will have to choose between some options)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="c1351de8b39808e0f027828afbaf48eafbefb36c" datatype="html">
         <source>Please specify:</source>
-        <target/>
+        <target state="final">Please specify:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">87</context>
@@ -373,17 +373,17 @@
       </trans-unit>
       <trans-unit id="2c67985932f0441af58f46be0b153bd30f39c5d9" datatype="html">
         <source>Type of organization is required</source>
-        <target/>
+        <target state="final">Type of organization is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">89</context>
         </context-group>
-        <note priority="1" from="description">Error message if the &apos;more specific&apos; type of organization field isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the 'more specific' type of organization field isn't supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="820d568fbf0cde2dd31e9f7d95fd4496a201189f" datatype="html">
         <source>Type of monitoring organization</source>
-        <target/>
+        <target state="final">Type of monitoring organization</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">93</context>
@@ -393,7 +393,7 @@
       </trans-unit>
       <trans-unit id="b06f369749b6fb40f9373986c261c239898aae3e" datatype="html">
         <source>Mandated</source>
-        <target/>
+        <target state="final">Mandated</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">95</context>
@@ -406,7 +406,7 @@
       </trans-unit>
       <trans-unit id="f06a9f71b004266aee89162657ea1c86d1315553" datatype="html">
         <source>Semi mandated</source>
-        <target/>
+        <target state="final">Semi mandated</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">96</context>
@@ -419,7 +419,7 @@
       </trans-unit>
       <trans-unit id="b56d7b02a4200f20c0f4889025281c8280e88f09" datatype="html">
         <source>Non-mandated (external)</source>
-        <target/>
+        <target state="final">Non-mandated (external)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">97</context>
@@ -428,27 +428,27 @@
       </trans-unit>
       <trans-unit id="683a0fe8c12c2ce250c6dd5194f545ae7748db21" datatype="html">
         <source>Please select a type of monitoring organization</source>
-        <target/>
+        <target state="final">Please select a type of monitoring organization</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">100</context>
         </context-group>
-        <note priority="1" from="description">Error message if the type of monitoring organization isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="description">Error message if the type of monitoring organization isn't supplied (the user will have to choose between some options)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="ea6416e29a89c5c714e69d898daba32eb41b698a" datatype="html">
         <source>Type of monitoring organization is required</source>
-        <target/>
+        <target state="final">Type of monitoring organization is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">106</context>
         </context-group>
-        <note priority="1" from="description">Error message if the &apos;more specific&apos; type of monitoring organization field isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the 'more specific' type of monitoring organization field isn't supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="3f26932174625c41427110ccc2226e504f5c6fbd" datatype="html">
         <source>Current independent monitoring project</source>
-        <target/>
+        <target state="final">Current independent monitoring project</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">110</context>
@@ -458,7 +458,7 @@
       </trans-unit>
       <trans-unit id="bf8439c857331fc455d3d031b6e2c60acf4389a9" datatype="html">
         <source>Project title</source>
-        <target/>
+        <target state="final">Project title</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">115</context>
@@ -476,17 +476,17 @@
       </trans-unit>
       <trans-unit id="b2140291449def6677aa53569b3c48d84a56c20b" datatype="html">
         <source>Project title is required</source>
-        <target/>
+        <target state="final">Project title is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">117</context>
         </context-group>
-        <note priority="1" from="description">Error message if the project title isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the project title isn't supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="8c78e20470679aab2f535754cbe129b99bb2df87" datatype="html">
         <source>Lead organization</source>
-        <target/>
+        <target state="final">Lead organization</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">121</context>
@@ -504,17 +504,17 @@
       </trans-unit>
       <trans-unit id="e4f0576d34d9e84843eacd1a69357b464c2778bd" datatype="html">
         <source>Lead organization is required</source>
-        <target/>
+        <target state="final">Lead organization is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">123</context>
         </context-group>
-        <note priority="1" from="description">Error message if the lead organization of a project isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the lead organization of a project isn't supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="7fdfd037df64f59dcc2e76a327cd2706aa70dd5d" datatype="html">
         <source>Start date</source>
-        <target/>
+        <target state="final">Start date</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">127</context>
@@ -532,17 +532,17 @@
       </trans-unit>
       <trans-unit id="3aba988d313ad1e91e0422e04026526c026e4344" datatype="html">
         <source>Start date is required</source>
-        <target/>
+        <target state="final">Start date is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">129</context>
         </context-group>
-        <note priority="1" from="description">Error message if the start date of a project isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the start date of a project isn't supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="a4cecf67712a605f7eb501374d3265fd12478cec" datatype="html">
         <source>Project duration (years)</source>
-        <target/>
+        <target state="final">Project duration (years)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">133</context>
@@ -560,17 +560,17 @@
       </trans-unit>
       <trans-unit id="32acf484fd94a7bbb5192328b88f846d21f96fb3" datatype="html">
         <source>Project duration is required</source>
-        <target/>
+        <target state="final">Project duration is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">135</context>
         </context-group>
-        <note priority="1" from="description">Error message if the duration in years of a project isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the duration in years of a project isn't supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="8a56af3ab6bb5ee118d69244fac33c11ab40a24b" datatype="html">
         <source>Donor(s)</source>
-        <target/>
+        <target state="final">Donor(s)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">139</context>
@@ -588,17 +588,17 @@
       </trans-unit>
       <trans-unit id="d1be0cb8729481903a941dcc95235e5df34d1144" datatype="html">
         <source>Donor(s) is required</source>
-        <target/>
+        <target state="final">Donor(s) is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">141</context>
         </context-group>
-        <note priority="1" from="description">Error message if the donor(s) isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the donor(s) isn't supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="6fd3fac713c24d0b1eb41ae210a92956dc47e067" datatype="html">
         <source>Project website</source>
-        <target/>
+        <target state="final">Project website</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">145</context>
@@ -616,7 +616,7 @@
       </trans-unit>
       <trans-unit id="61db125afe28f6cda94785420bbad6344cd6db25" datatype="html">
         <source>Additional information on status, progress, etc.</source>
-        <target/>
+        <target state="final">Additional information on status, progress, etc.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">150</context>
@@ -634,7 +634,7 @@
       </trans-unit>
       <trans-unit id="49819b177c45f46e71178ef87bc2888c67948703" datatype="html">
         <source>Website link</source>
-        <target/>
+        <target state="final">Website link</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">161</context>
@@ -644,17 +644,17 @@
       </trans-unit>
       <trans-unit id="dfc9e62e50d1da01fa8fd0b6b7bcc02a6816d784" datatype="html">
         <source>Organisation’s mission (max 250 characters)</source>
-        <target/>
+        <target state="final">Organisation’s mission (max 250 characters)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">166</context>
         </context-group>
-        <note priority="1" from="description">Label for the organization&apos;s mission field (with a limit of 250 chars)</note>
+        <note priority="1" from="description">Label for the organization's mission field (with a limit of 250 chars)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="e132818042799ae0d6af75d59ecfe7ad2997a9c5" datatype="html">
         <source>You exceed the maximum number of characters</source>
-        <target/>
+        <target state="final">You exceed the maximum number of characters</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">168</context>
@@ -663,12 +663,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">174</context>
         </context-group>
-        <note priority="1" from="description">Error message if the organization&apos;s mission exceeds 250 chars</note>
+        <note priority="1" from="description">Error message if the organization's mission exceeds 250 chars</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="6bf5e59e896974c50b48e83196c5cf1b334791cb" datatype="html">
         <source>Quality control (max 500 characters)</source>
-        <target/>
+        <target state="final">Quality control (max 500 characters)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">172</context>
@@ -678,17 +678,17 @@
       </trans-unit>
       <trans-unit id="9714e9ae169a4c3cd16f982682d05002706c3e75" datatype="html">
         <source>Geographical scope of work</source>
-        <target/>
+        <target state="final">Geographical scope of work</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">178</context>
         </context-group>
-        <note priority="1" from="description">Label for the organization&apos;s geographical scope field</note>
+        <note priority="1" from="description">Label for the organization's geographical scope field</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="c7ec8a666155407083e0df211e21f1bddc5b5304" datatype="html">
         <source>Sub-national</source>
-        <target/>
+        <target state="final">Sub-national</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">180</context>
@@ -697,7 +697,7 @@
       </trans-unit>
       <trans-unit id="4ebd5411731ecbd28a246b00fbe62d5e76356d36" datatype="html">
         <source>National</source>
-        <target/>
+        <target state="final">National</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">181</context>
@@ -706,7 +706,7 @@
       </trans-unit>
       <trans-unit id="cb683c4a7564df4ad793eedad2a5ac342ecf5c12" datatype="html">
         <source>International</source>
-        <target/>
+        <target state="final">International</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">182</context>
@@ -715,7 +715,7 @@
       </trans-unit>
       <trans-unit id="d3cbd7eedb32d830d50c4ca6e0f2440b00af4c6c" datatype="html">
         <source>Project 1</source>
-        <target/>
+        <target state="final">Project 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">194</context>
@@ -725,7 +725,7 @@
       </trans-unit>
       <trans-unit id="c518f75c849d225f2ca6141925c505dd9606ec2e" datatype="html">
         <source>Project 2</source>
-        <target/>
+        <target state="final">Project 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">239</context>
@@ -735,7 +735,7 @@
       </trans-unit>
       <trans-unit id="6a6369d9cf34dd7374275a93fea20c243877bf99" datatype="html">
         <source>Less details</source>
-        <target/>
+        <target state="final">Less details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">291</context>
@@ -744,7 +744,7 @@
       </trans-unit>
       <trans-unit id="711a50f8cce91ebfb36614abe4e25c400480c269" datatype="html">
         <source>More details</source>
-        <target/>
+        <target state="final">More details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">292</context>
@@ -753,7 +753,7 @@
       </trans-unit>
       <trans-unit id="b4b9d2e75328589d6f50655d26d370b8a8168365" datatype="html">
         <source>Discard changes</source>
-        <target/>
+        <target state="final">Discard changes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">303</context>
@@ -762,7 +762,7 @@
       </trans-unit>
       <trans-unit id="5b3075e8dc3f3921ec316b0bd83b6d14a06c1a4f" datatype="html">
         <source>Save changes</source>
-        <target/>
+        <target state="final">Save changes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">304</context>
@@ -771,7 +771,7 @@
       </trans-unit>
       <trans-unit id="dafa8a6b3ce5af28ce08ad9b57a82328126b5003" datatype="html">
         <source>Update observation</source>
-        <target/>
+        <target state="final">Update observation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -781,7 +781,7 @@
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
-        <target/>
+        <target state="final">Cancel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -930,7 +930,7 @@
       </trans-unit>
       <trans-unit id="047f50bc5b5d17b5bec0196355953e1a5c590ddb" datatype="html">
         <source>Update</source>
-        <target/>
+        <target state="final">Update</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">7</context>
@@ -959,7 +959,7 @@
       </trans-unit>
       <trans-unit id="2ced27c89ab044b68b5fc5f112e9fdb823d78073" datatype="html">
         <source>Type</source>
-        <target/>
+        <target state="final">Type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -973,7 +973,7 @@
       </trans-unit>
       <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
         <source>Operator</source>
-        <target/>
+        <target state="final">Operator</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -986,7 +986,7 @@
       </trans-unit>
       <trans-unit id="edd600fa489d1b4a4448dce694ed932e52ce8fda" datatype="html">
         <source>Governance</source>
-        <target/>
+        <target state="final">Governance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">17</context>
@@ -999,7 +999,7 @@
       </trans-unit>
       <trans-unit id="8ac4ffef0bab3e3fef5a739f8f0659a27edbf5ab" datatype="html">
         <source>Country</source>
-        <target/>
+        <target state="final">Country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">24</context>
@@ -1013,7 +1013,7 @@
       </trans-unit>
       <trans-unit id="66c8bc89c06a678f7956435165f15539fb6fcbf9" datatype="html">
         <source>Please select a country</source>
-        <target/>
+        <target state="final">Please select a country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">29</context>
@@ -1022,12 +1022,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">28</context>
         </context-group>
-        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the country isn't supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="f81df4984ec9a7a25ca1a255e70c37cf0b3fc768" datatype="html">
         <source>Latitude</source>
-        <target/>
+        <target state="final">Latitude</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -1041,7 +1041,7 @@
       </trans-unit>
       <trans-unit id="9103deeab9ec8e9c404a9b613f32c40f8b81435b" datatype="html">
         <source>Latitude is required</source>
-        <target/>
+        <target state="final">Latitude is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">36</context>
@@ -1050,12 +1050,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <note priority="1" from="description">Error message if the latitude isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the latitude isn't supplied</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="4d643d02cb8a26d011ecbc2cc65e36d6c79285b6" datatype="html">
         <source>Please enter a valid number</source>
-        <target/>
+        <target state="final">Please enter a valid number</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -1072,12 +1072,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">42</context>
         </context-group>
-        <note priority="1" from="description">Error message if the latitude isn&apos;t valid</note>
+        <note priority="1" from="description">Error message if the latitude isn't valid</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="bcb1edd093495a7f451ec73bda71a390fd9b7bb0" datatype="html">
         <source>Longitude</source>
-        <target/>
+        <target state="final">Longitude</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">41</context>
@@ -1091,7 +1091,7 @@
       </trans-unit>
       <trans-unit id="dfe47cc2c10ef51aec72676718979323da406949" datatype="html">
         <source>Longitude is required</source>
-        <target/>
+        <target state="final">Longitude is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">44</context>
@@ -1100,12 +1100,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">41</context>
         </context-group>
-        <note priority="1" from="description">Error message if the longitude isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the longitude isn't supplied</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="47147103a9753d3a57d16858149ad097aef3a20c" datatype="html">
         <source>Sub-category</source>
-        <target/>
+        <target state="final">Sub-category</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">49</context>
@@ -1127,7 +1127,7 @@
       </trans-unit>
       <trans-unit id="6bedd241a7533daaee02997b78ec87bdd2d2fb5a" datatype="html">
         <source>Please select a sub-category</source>
-        <target/>
+        <target state="final">Please select a sub-category</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">54</context>
@@ -1144,12 +1144,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">60</context>
         </context-group>
-        <note priority="1" from="description">Error message if the sub-category isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the sub-category isn't supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="2836d984c7fd9f88dde6ca18f69d18ae66c268e2" datatype="html">
         <source>Severity</source>
-        <target/>
+        <target state="final">Severity</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">67</context>
@@ -1163,7 +1163,7 @@
       </trans-unit>
       <trans-unit id="4f9d0961548c19b80893a1354e2ffd8dad7347f4" datatype="html">
         <source>Please select a severity</source>
-        <target/>
+        <target state="final">Please select a severity</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">72</context>
@@ -1172,12 +1172,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">68</context>
         </context-group>
-        <note priority="1" from="description">Error message if the severity isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the severity isn't supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="1497e5043b0c1da86c5469b69d4c7497ff523438" datatype="html">
         <source>Publication date</source>
-        <target/>
+        <target state="final">Publication date</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">76</context>
@@ -1191,7 +1191,7 @@
       </trans-unit>
       <trans-unit id="849521cde58edf20f3e8b3d596c0b4843603b3e8" datatype="html">
         <source>Publication date is required</source>
-        <target/>
+        <target state="final">Publication date is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">78</context>
@@ -1200,12 +1200,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">74</context>
         </context-group>
-        <note priority="1" from="description">Error message if the publication date isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the publication date isn't supplied</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="59cfebb84dc089e652e54b56dfd1127f5331bd8c" datatype="html">
         <source>Government Entity</source>
-        <target/>
+        <target state="final">Government Entity</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">82</context>
@@ -1219,7 +1219,7 @@
       </trans-unit>
       <trans-unit id="f0fd741b7784b50be4e7de22cc464106848b6673" datatype="html">
         <source>Please select a government entity</source>
-        <target/>
+        <target state="final">Please select a government entity</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">86</context>
@@ -1228,12 +1228,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">82</context>
         </context-group>
-        <note priority="1" from="description">Error message if the government entity isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the government entity isn't supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="755a1c920f1be9572a38de2d2b0dda3b701c78f4" datatype="html">
         <source>PV</source>
-        <target/>
+        <target state="final">PV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">90</context>
@@ -1247,7 +1247,7 @@
       </trans-unit>
       <trans-unit id="7ced18ad4df34b20929de05b0ebe6bfa213c5472" datatype="html">
         <source>Opinion of operator</source>
-        <target/>
+        <target state="final">Opinion of operator</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">95</context>
@@ -1261,7 +1261,7 @@
       </trans-unit>
       <trans-unit id="f066e1eb28d8ae8a8877b138277b4c05e1c0c226" datatype="html">
         <source>Litigation status</source>
-        <target/>
+        <target state="final">Litigation status</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">101</context>
@@ -1275,7 +1275,7 @@
       </trans-unit>
       <trans-unit id="b4a2de6607352730a6af5fcb59263e27439f2c5a" datatype="html">
         <source>Monitor</source>
-        <target/>
+        <target state="final">Monitor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">107</context>
@@ -1289,7 +1289,7 @@
       </trans-unit>
       <trans-unit id="ffeb07b7af4b3905ed99ac72ad636ca63bc05dc8" datatype="html">
         <source>Please select a monitor</source>
-        <target/>
+        <target state="final">Please select a monitor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">111</context>
@@ -1298,12 +1298,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">105</context>
         </context-group>
-        <note priority="1" from="description">Error message if the monitor isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the monitor isn't supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="dd2f34de17cff8207d4e0ec104bc093faac2b8eb" datatype="html">
         <source>Operator</source>
-        <target/>
+        <target state="final">Operator</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">115</context>
@@ -1317,7 +1317,7 @@
       </trans-unit>
       <trans-unit id="c70b9e0c5e8e83b7427e178e4f95ab6559c43224" datatype="html">
         <source>Please select an operator</source>
-        <target/>
+        <target state="final">Please select an operator</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">119</context>
@@ -1326,12 +1326,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">113</context>
         </context-group>
-        <note priority="1" from="description">Error message if the operator isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the operator isn't supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="711d402d0117e5b0abb02c988648b9c41ea13975" datatype="html">
         <source>Active</source>
-        <target/>
+        <target state="final">Active</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">123</context>
@@ -1345,7 +1345,7 @@
       </trans-unit>
       <trans-unit id="c324d1ec6ff085cd19e6bce739b05ad9475e0672" datatype="html">
         <source>Details</source>
-        <target/>
+        <target state="final">Details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">128</context>
@@ -1359,7 +1359,7 @@
       </trans-unit>
       <trans-unit id="7e9e4e7c021c606a03a4cd3f5b9331bd37fb109d" datatype="html">
         <source>Evidence</source>
-        <target/>
+        <target state="final">Evidence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">133</context>
@@ -1375,7 +1375,9 @@
         <source>
       New governance sub-category
     </source>
-        <target/>
+        <target state="final">
+      New governance sub-category
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -1384,7 +1386,7 @@
       </trans-unit>
       <trans-unit id="f59e607fb08307278ff4d632a8403cc7250f40b7" datatype="html">
         <source>Governance Pillar</source>
-        <target/>
+        <target state="final">Governance Pillar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -1394,7 +1396,7 @@
       </trans-unit>
       <trans-unit id="646cbe17a5d08e57cb34928dfe7fa7cd23481ce0" datatype="html">
         <source>Governance Problem</source>
-        <target/>
+        <target state="final">Governance Problem</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -1404,7 +1406,7 @@
       </trans-unit>
       <trans-unit id="f5f4971be2896724f7402e018c02e4998d0f7165" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -1414,7 +1416,7 @@
       </trans-unit>
       <trans-unit id="7d29efb5dea57b061811390c578b3c386ac28802" datatype="html">
         <source>Sub-categories (Governance)</source>
-        <target/>
+        <target state="final">Sub-categories (Governance)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -1423,7 +1425,7 @@
       </trans-unit>
       <trans-unit id="9c16ee275da84e3a95d9ee5f7bb01a42ef3df5b2" datatype="html">
         <source>New governance sub-category</source>
-        <target/>
+        <target state="final">New governance sub-category</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -1433,7 +1435,7 @@
       </trans-unit>
       <trans-unit id="7891175220c7fe8e6e94d10cf7726ede071792fc" datatype="html">
         <source>Update governance sub-category</source>
-        <target/>
+        <target state="final">Update governance sub-category</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -1443,7 +1445,7 @@
       </trans-unit>
       <trans-unit id="70a67e04629f6d412db0a12d51820b480788d795" datatype="html">
         <source>Create</source>
-        <target/>
+        <target state="final">Create</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -1580,7 +1582,7 @@
       </trans-unit>
       <trans-unit id="6909f80c54d37a94153b18d639d4dbf990634bf7" datatype="html">
         <source>Governance pillar</source>
-        <target/>
+        <target state="final">Governance pillar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -1590,17 +1592,17 @@
       </trans-unit>
       <trans-unit id="6ed681ff2468c607172396fc02a073dac8b4efaf" datatype="html">
         <source>Governance pillar is required</source>
-        <target/>
+        <target state="final">Governance pillar is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the governance pillar isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the governance pillar isn't supplied</note>
         <note priority="1" from="meaning">Governance sub-category creation/edition</note>
       </trans-unit>
       <trans-unit id="a7dc4236b38404ed8d4aa4c9fb780ccc040ccd9e" datatype="html">
         <source>Governance problem</source>
-        <target/>
+        <target state="final">Governance problem</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">21</context>
@@ -1610,17 +1612,17 @@
       </trans-unit>
       <trans-unit id="54b7e1b3b75e6445b2f2e6784cb3be46286ea10d" datatype="html">
         <source>Governance problem is required</source>
-        <target/>
+        <target state="final">Governance problem is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">23</context>
         </context-group>
-        <note priority="1" from="description">Error message if the governance problem isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the governance problem isn't supplied</note>
         <note priority="1" from="meaning">Governance sub-category creation/edition</note>
       </trans-unit>
       <trans-unit id="c277d5768b2a4c5b1925b6c0dc7ec58ae1bc1d05" datatype="html">
         <source>Details</source>
-        <target/>
+        <target state="final">Details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">26</context>
@@ -1632,7 +1634,9 @@
         <source>
       New operator sub-category
     </source>
-        <target/>
+        <target state="final">
+      New operator sub-category
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -1641,7 +1645,7 @@
       </trans-unit>
       <trans-unit id="400ca8ca7107a0d8e8929b04d8fc4c185d183f1b" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -1651,7 +1655,7 @@
       </trans-unit>
       <trans-unit id="31f4b66a2ffe7471f4f39930204bc4f382f5dfd3" datatype="html">
         <source>Details</source>
-        <target/>
+        <target state="final">Details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -1661,7 +1665,7 @@
       </trans-unit>
       <trans-unit id="f63250c4baab4b9281bc0babcc6ff86338771d19" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -1671,7 +1675,7 @@
       </trans-unit>
       <trans-unit id="01913c9d313d04a592d6aa364ad1e8b13717cd42" datatype="html">
         <source>Sub-categories (Operators)</source>
-        <target/>
+        <target state="final">Sub-categories (Operators)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -1680,7 +1684,7 @@
       </trans-unit>
       <trans-unit id="1da555b26e38aea784e23a1092afa8ba60693dbb" datatype="html">
         <source>New operator sub-category</source>
-        <target/>
+        <target state="final">New operator sub-category</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -1690,7 +1694,7 @@
       </trans-unit>
       <trans-unit id="773e146f4baed993f7e61607302504f702ebef35" datatype="html">
         <source>Update operator sub-category</source>
-        <target/>
+        <target state="final">Update operator sub-category</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -1700,7 +1704,7 @@
       </trans-unit>
       <trans-unit id="8e29884856ab62e66baed2206fe9f251c542932e" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -1710,17 +1714,17 @@
       </trans-unit>
       <trans-unit id="cf8f4120bf44e9a770d8d4ec2cf0f68c2db7f24e" datatype="html">
         <source>Name is required</source>
-        <target/>
+        <target state="final">Name is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the name isn't supplied</note>
         <note priority="1" from="meaning">Operator sub-category creation/edition</note>
       </trans-unit>
       <trans-unit id="e5ed666f8f6a2589cd3c7979b243e5bc6f78d60d" datatype="html">
         <source>Country</source>
-        <target/>
+        <target state="final">Country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -1730,7 +1734,7 @@
       </trans-unit>
       <trans-unit id="1ca5483adf9af728d5d0a98cd364a694cc422e63" datatype="html">
         <source>Law references</source>
-        <target/>
+        <target state="final">Law references</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">29</context>
@@ -1740,7 +1744,7 @@
       </trans-unit>
       <trans-unit id="0a6091f7c64135d8ec9439019908e8f1e6d28d6b" datatype="html">
         <source>Details</source>
-        <target/>
+        <target state="final">Details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">36</context>
@@ -1750,7 +1754,7 @@
       </trans-unit>
       <trans-unit id="ad9508c67f58f44fd3b4d73925e50fa53de76fb7" datatype="html">
         <source>Operators</source>
-        <target/>
+        <target state="final">Operators</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/subcategories.component.ts</context>
           <context context-type="linenumber">2</context>
@@ -1767,12 +1771,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">4</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;Sub-categories&apos; list page</note>
+        <note priority="1" from="description">Menu located on the 'Sub-categories' list page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="cefad27e0f05695d2e7d84403f5370fa0ac85c5f" datatype="html">
         <source>Governance</source>
-        <target/>
+        <target state="final">Governance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/subcategories.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -1781,12 +1785,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">5</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;Sub-categories&apos; list page</note>
+        <note priority="1" from="description">Menu located on the 'Sub-categories' list page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="85afe36487fab2e70904c3d796f0ea2f7a5a90a9" datatype="html">
         <source>New category</source>
-        <target/>
+        <target state="final">New category</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -1796,7 +1800,7 @@
       </trans-unit>
       <trans-unit id="c9315cc027fda44df7772e7fa05aa74402dc017d" datatype="html">
         <source>Update category</source>
-        <target/>
+        <target state="final">Update category</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -1806,7 +1810,7 @@
       </trans-unit>
       <trans-unit id="48df2497540119700a2d0e0f26d629c837fd7fc6" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -1816,19 +1820,21 @@
       </trans-unit>
       <trans-unit id="2637b135fb7dc9dab5d9b2cd507716b80cb98240" datatype="html">
         <source>Name is required</source>
-        <target/>
+        <target state="final">Name is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the name isn't supplied</note>
         <note priority="1" from="meaning">Category creation/edition</note>
       </trans-unit>
       <trans-unit id="d3392cb23bca77d1014e89b5e8aefcfb4ccad87b" datatype="html">
         <source>
       New Operator
     </source>
-        <target/>
+        <target state="final">
+      New Operator
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -1837,7 +1843,7 @@
       </trans-unit>
       <trans-unit id="801e19d7c8bfcbcc9ede4749d1885f45759b8c8b" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -1851,7 +1857,7 @@
       </trans-unit>
       <trans-unit id="60a3c060cf7bbe40ffbfc35b0b3bb691a789a4e7" datatype="html">
         <source>Type</source>
-        <target/>
+        <target state="final">Type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -1861,7 +1867,7 @@
       </trans-unit>
       <trans-unit id="4f00329eba86dfea8ce882af55cbe475c00c1036" datatype="html">
         <source>Concession</source>
-        <target/>
+        <target state="final">Concession</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -1871,7 +1877,7 @@
       </trans-unit>
       <trans-unit id="b029eee35172b814101cf828fb5f9a61e1391c0f" datatype="html">
         <source>Active</source>
-        <target/>
+        <target state="final">Active</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -1881,7 +1887,7 @@
       </trans-unit>
       <trans-unit id="39ffe1e95aa519b9645e62af04ed0a3cfa032b42" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -1891,7 +1897,7 @@
       </trans-unit>
       <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
         <source>Operators</source>
-        <target/>
+        <target state="final">Operators</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -1900,7 +1906,7 @@
       </trans-unit>
       <trans-unit id="1dbd4bf0057e786321c83ca35a3c4e2b77f181a9" datatype="html">
         <source>New operator</source>
-        <target/>
+        <target state="final">New operator</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -1910,7 +1916,7 @@
       </trans-unit>
       <trans-unit id="f0a8d16cabce095b3508ff9dbeb0459b33249e5d" datatype="html">
         <source>Update operator</source>
-        <target/>
+        <target state="final">Update operator</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -1920,7 +1926,7 @@
       </trans-unit>
       <trans-unit id="9fd38b8fcd5e17ff3611d046ce724e16a2000109" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -1930,17 +1936,17 @@
       </trans-unit>
       <trans-unit id="77728cbe1d84a03b45077d0bcdb10f2ccbeb223e" datatype="html">
         <source>Name is required</source>
-        <target/>
+        <target state="final">Name is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the name isn't supplied</note>
         <note priority="1" from="meaning">Operator creation/edition</note>
       </trans-unit>
       <trans-unit id="f152c650bc08e63a3b7a2471c3ef3ab62cf3d52b" datatype="html">
         <source>Operator type</source>
-        <target/>
+        <target state="final">Operator type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -1950,7 +1956,7 @@
       </trans-unit>
       <trans-unit id="2a0e9f550a391aa5b4639d2c85ba060358390726" datatype="html">
         <source>Logging</source>
-        <target/>
+        <target state="final">Logging</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">24</context>
@@ -1959,7 +1965,7 @@
       </trans-unit>
       <trans-unit id="6ef0619a37140118b9e640c6cc36ee4e9fb4372a" datatype="html">
         <source>Company</source>
-        <target/>
+        <target state="final">Company</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">25</context>
@@ -1972,7 +1978,7 @@
       </trans-unit>
       <trans-unit id="99186438c83c4c7e8b9cc78dfa43f7fd524b5e6e" datatype="html">
         <source>Artisanal</source>
-        <target/>
+        <target state="final">Artisanal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">26</context>
@@ -1981,7 +1987,7 @@
       </trans-unit>
       <trans-unit id="0ad4531bb4bd5e0c7770dfdd89a99befcad6c8ea" datatype="html">
         <source>Sawmill</source>
-        <target/>
+        <target state="final">Sawmill</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">27</context>
@@ -1990,7 +1996,7 @@
       </trans-unit>
       <trans-unit id="f5a5b7fe27eecc145ce874a267d55abd47590494" datatype="html">
         <source>Community Forest</source>
-        <target/>
+        <target state="final">Community Forest</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">28</context>
@@ -1999,7 +2005,7 @@
       </trans-unit>
       <trans-unit id="e856ab987b69555ee8e5f8cd7e442de3eabea7f4" datatype="html">
         <source>ARB1327</source>
-        <target/>
+        <target state="final">ARB1327</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">29</context>
@@ -2008,7 +2014,7 @@
       </trans-unit>
       <trans-unit id="33cf379d245d5fb087711431420fb0ef6ed3e43b" datatype="html">
         <source>Palm Oil</source>
-        <target/>
+        <target state="final">Palm Oil</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">30</context>
@@ -2017,7 +2023,7 @@
       </trans-unit>
       <trans-unit id="5d79e032a7657d92b56373c5cc20d0724ef9c73a" datatype="html">
         <source>Trader</source>
-        <target/>
+        <target state="final">Trader</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">31</context>
@@ -2026,12 +2032,12 @@
       </trans-unit>
       <trans-unit id="cafbab33e33e79a58b4eefad43938b99d0426314" datatype="html">
         <source>Please select an operator type</source>
-        <target/>
+        <target state="final">Please select an operator type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <note priority="1" from="description">Error message if the operator type isn&apos;t supplied (the user will have to choose between several options)</note>
+        <note priority="1" from="description">Error message if the operator type isn't supplied (the user will have to choose between several options)</note>
         <note priority="1" from="meaning">Operator creation/edition</note>
       </trans-unit>
       <trans-unit id="fe69558920c9d7980d3f3acf5c1ac18191b180d9" datatype="html">
@@ -2041,7 +2047,12 @@
         <x id="START_TAG_OPTION" ctype="x-option"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_OPTION" ctype="x-option"/>
       <x id="CLOSE_TAG_SELECT" ctype="x-select"/>
     </source>
-        <target/>
+        <target state="final">
+      <x id="START_TAG_LABEL" ctype="x-label"/>Country<x id="CLOSE_TAG_LABEL" ctype="x-label"/>
+      <x id="START_TAG_SELECT" ctype="x-select"/>
+        <x id="START_TAG_OPTION" ctype="x-option"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_OPTION" ctype="x-option"/>
+      <x id="CLOSE_TAG_SELECT" ctype="x-select"/>
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -2051,7 +2062,7 @@
       </trans-unit>
       <trans-unit id="8c88e1c3c79928abc132f9da3d38a81a8511fa0a" datatype="html">
         <source>Concession</source>
-        <target/>
+        <target state="final">Concession</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">45</context>
@@ -2061,7 +2072,7 @@
       </trans-unit>
       <trans-unit id="3934c8285a2371995bd611a986efcbfa9253b8e2" datatype="html">
         <source>Country centroid</source>
-        <target/>
+        <target state="final">Country centroid</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">50</context>
@@ -2071,7 +2082,7 @@
       </trans-unit>
       <trans-unit id="1e033c6c092d12800660484eec7a772925639eb6" datatype="html">
         <source>Active</source>
-        <target/>
+        <target state="final">Active</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">55</context>
@@ -2083,7 +2094,9 @@
         <source>
       New Country
     </source>
-        <target/>
+        <target state="final">
+      New Country
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2092,7 +2105,7 @@
       </trans-unit>
       <trans-unit id="de0beb4f2c7b3619f47224ad8a5feedb860dfc0c" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2102,7 +2115,7 @@
       </trans-unit>
       <trans-unit id="b9d28a4b3787fdb725362102e55e54541497723c" datatype="html">
         <source>ISO</source>
-        <target/>
+        <target state="final">ISO</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2112,7 +2125,7 @@
       </trans-unit>
       <trans-unit id="902f1ade07cad3f447858b17c2da63e8f7e26ce8" datatype="html">
         <source>Region Name</source>
-        <target/>
+        <target state="final">Region Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2122,7 +2135,7 @@
       </trans-unit>
       <trans-unit id="6bb7c94296bdb62165caa3ed3e9151390c0811f9" datatype="html">
         <source>Active</source>
-        <target/>
+        <target state="final">Active</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -2132,7 +2145,7 @@
       </trans-unit>
       <trans-unit id="ab07255a444e77bef3e19ddaca4b72a1c8eb360e" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -2142,7 +2155,7 @@
       </trans-unit>
       <trans-unit id="aee7d0de4e30405c1289745e4264e622b613632a" datatype="html">
         <source>Countries</source>
-        <target/>
+        <target state="final">Countries</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2151,7 +2164,7 @@
       </trans-unit>
       <trans-unit id="e4a0e02a470737d8053a8ced70e98d1978442484" datatype="html">
         <source>New country</source>
-        <target/>
+        <target state="final">New country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -2161,7 +2174,7 @@
       </trans-unit>
       <trans-unit id="c9eed87bc1809a6190cb533f6e034c8c240721ea" datatype="html">
         <source>Update country</source>
-        <target/>
+        <target state="final">Update country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2171,7 +2184,7 @@
       </trans-unit>
       <trans-unit id="f9a075ede38c8f0b8e1ebc8a636ff9c2e1d2d5ac" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -2181,17 +2194,17 @@
       </trans-unit>
       <trans-unit id="7772f40a6bf4492246a964933bcd562d63690558" datatype="html">
         <source>Name is required</source>
-        <target/>
+        <target state="final">Name is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the name isn't supplied</note>
         <note priority="1" from="meaning">Country creation/edition</note>
       </trans-unit>
       <trans-unit id="fa04f51e70170a51b8409850619f58194170bf81" datatype="html">
         <source>Region name</source>
-        <target/>
+        <target state="final">Region name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -2201,7 +2214,7 @@
       </trans-unit>
       <trans-unit id="5620a84efc9854a3c1c04b51762b8c12ff7ba334" datatype="html">
         <source>ISO</source>
-        <target/>
+        <target state="final">ISO</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">27</context>
@@ -2211,17 +2224,17 @@
       </trans-unit>
       <trans-unit id="85c0d8144b112baf450f3265187ed54f3cedb65a" datatype="html">
         <source>ISO is required</source>
-        <target/>
+        <target state="final">ISO is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">29</context>
         </context-group>
-        <note priority="1" from="description">Error message if the ISO code isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the ISO code isn't supplied</note>
         <note priority="1" from="meaning">Country creation/edition</note>
       </trans-unit>
       <trans-unit id="2808eef1afd0850f3fc4d5bb4af9c8d760a83537" datatype="html">
         <source>Region ISO</source>
-        <target/>
+        <target state="final">Region ISO</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -2231,7 +2244,7 @@
       </trans-unit>
       <trans-unit id="f4ba7b2b4ecc25e0b57747d4cc613996662cb0c4" datatype="html">
         <source>Country centroid</source>
-        <target/>
+        <target state="final">Country centroid</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">38</context>
@@ -2241,7 +2254,7 @@
       </trans-unit>
       <trans-unit id="6dc87818baaf0762c2e63182ecbf55ef11907b2a" datatype="html">
         <source>Region centroid</source>
-        <target/>
+        <target state="final">Region centroid</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">43</context>
@@ -2251,7 +2264,7 @@
       </trans-unit>
       <trans-unit id="8a1e8e453f1ca7b66f462780f073fd214fd7a012" datatype="html">
         <source>Available for observations?</source>
-        <target/>
+        <target state="final">Available for observations?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">48</context>
@@ -2263,7 +2276,9 @@
         <source>
       New species
     </source>
-        <target/>
+        <target state="final">
+      New species
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2272,7 +2287,7 @@
       </trans-unit>
       <trans-unit id="7d1762ee4d496a6c991fde6dcfbec7af4144c1cc" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2282,7 +2297,7 @@
       </trans-unit>
       <trans-unit id="79c4cd49d2cd2f84007b9e115400686f56986a1e" datatype="html">
         <source>Species class</source>
-        <target/>
+        <target state="final">Species class</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2292,7 +2307,7 @@
       </trans-unit>
       <trans-unit id="c7703ff5d60e6ef26ff13b44cbb0265e145a1888" datatype="html">
         <source>Scientific name</source>
-        <target/>
+        <target state="final">Scientific name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2302,7 +2317,7 @@
       </trans-unit>
       <trans-unit id="6a5cd6a6798a329a413178bdbbbe22c5edd66d89" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -2312,7 +2327,7 @@
       </trans-unit>
       <trans-unit id="ec2b122ed8617f51ed128267a65711e40e56b5bc" datatype="html">
         <source>Species</source>
-        <target/>
+        <target state="final">Species</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2323,7 +2338,9 @@
         <source>
       New Monitor
     </source>
-        <target/>
+        <target state="final">
+      New Monitor
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2332,7 +2349,7 @@
       </trans-unit>
       <trans-unit id="ebe3ca55e2a451ca15ee5d9b7310f0377b6e2b0e" datatype="html">
         <source>Date</source>
-        <target/>
+        <target state="final">Date</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2342,7 +2359,7 @@
       </trans-unit>
       <trans-unit id="c818c652325d319c5fa88875471f20eb663a12b3" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2352,7 +2369,7 @@
       </trans-unit>
       <trans-unit id="b2ef1717958c380c23c8921591715b7fbaf91cb8" datatype="html">
         <source>Type</source>
-        <target/>
+        <target state="final">Type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2362,7 +2379,7 @@
       </trans-unit>
       <trans-unit id="b1d9f070c335abb9c7877c5effde44fc31d7346c" datatype="html">
         <source>Organization</source>
-        <target/>
+        <target state="final">Organization</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -2372,7 +2389,7 @@
       </trans-unit>
       <trans-unit id="b4237c13c658454f4a55897e4a3cf73c30a80e0e" datatype="html">
         <source>Active</source>
-        <target/>
+        <target state="final">Active</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -2382,7 +2399,7 @@
       </trans-unit>
       <trans-unit id="53e3ce2b1d00ae0c8f1f2d8cabbab9cfd91c67ff" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">15</context>
@@ -2394,7 +2411,9 @@
         <source>
       New law
     </source>
-        <target/>
+        <target state="final">
+      New law
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2403,7 +2422,7 @@
       </trans-unit>
       <trans-unit id="67572ae9cc69d32f40b3259490b91cecc3f5f85d" datatype="html">
         <source>Legal Reference</source>
-        <target/>
+        <target state="final">Legal Reference</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2413,7 +2432,7 @@
       </trans-unit>
       <trans-unit id="94380867a6d2b9b39396e6754e7d10d8ebe9085e" datatype="html">
         <source>Legal Penalty</source>
-        <target/>
+        <target state="final">Legal Penalty</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2423,7 +2442,7 @@
       </trans-unit>
       <trans-unit id="8070d4dfa7c8357d6d5ce2b1f920d6d584dc9cdc" datatype="html">
         <source>VPA indicator</source>
-        <target/>
+        <target state="final">VPA indicator</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -2433,7 +2452,7 @@
       </trans-unit>
       <trans-unit id="0610fd99f9f9b25f432fb2bd65249748420efc70" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -2443,7 +2462,7 @@
       </trans-unit>
       <trans-unit id="d9f85cde7086ccd4c97fc1ae6e656dd68db51d4b" datatype="html">
         <source>Laws</source>
-        <target/>
+        <target state="final">Laws</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2452,7 +2471,7 @@
       </trans-unit>
       <trans-unit id="ebc02487572b7b91efac0f364a963de1836fc422" datatype="html">
         <source>New species</source>
-        <target/>
+        <target state="final">New species</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2462,7 +2481,7 @@
       </trans-unit>
       <trans-unit id="4e20ed317e78bb9276d249261909b0dd7b89fdbe" datatype="html">
         <source>Update species</source>
-        <target/>
+        <target state="final">Update species</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -2472,7 +2491,7 @@
       </trans-unit>
       <trans-unit id="9450101fd324b122e3c2eebe39ea1efb73ed835a" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">17</context>
@@ -2482,17 +2501,17 @@
       </trans-unit>
       <trans-unit id="6e79c544a6f881f3b2bc6c311136b1b07e61db80" datatype="html">
         <source>Name is required</source>
-        <target/>
+        <target state="final">Name is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the name isn't supplied</note>
         <note priority="1" from="meaning">Species creation/edition</note>
       </trans-unit>
       <trans-unit id="6513c8fc3343f39e6523ebcb32977f7fd74a6042" datatype="html">
         <source>Common name</source>
-        <target/>
+        <target state="final">Common name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">23</context>
@@ -2502,7 +2521,7 @@
       </trans-unit>
       <trans-unit id="dd0a5f500aef0ecaac829d038616a1c561b644e7" datatype="html">
         <source>Scientific name</source>
-        <target/>
+        <target state="final">Scientific name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">28</context>
@@ -2512,7 +2531,7 @@
       </trans-unit>
       <trans-unit id="2cbd3b29e44968bc1915613d5cd3e31b41237adb" datatype="html">
         <source>Species class</source>
-        <target/>
+        <target state="final">Species class</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -2522,7 +2541,7 @@
       </trans-unit>
       <trans-unit id="53f592247ce5bd687d87c9e07f6d9eed9d30da20" datatype="html">
         <source>Sub species</source>
-        <target/>
+        <target state="final">Sub species</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">38</context>
@@ -2532,7 +2551,7 @@
       </trans-unit>
       <trans-unit id="20b6a2bdb411d5ee55c944816a0632c5f4ce8917" datatype="html">
         <source>Species family</source>
-        <target/>
+        <target state="final">Species family</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">43</context>
@@ -2542,7 +2561,7 @@
       </trans-unit>
       <trans-unit id="f2203853494dd5e56d65f8ec663b0a9c5d627b55" datatype="html">
         <source>Kingdom</source>
-        <target/>
+        <target state="final">Kingdom</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">48</context>
@@ -2552,7 +2571,7 @@
       </trans-unit>
       <trans-unit id="d1cd8111b4fe023923f890c0a7c44cc94cada286" datatype="html">
         <source>CITES status</source>
-        <target/>
+        <target state="final">CITES status</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">53</context>
@@ -2562,7 +2581,7 @@
       </trans-unit>
       <trans-unit id="1f823441a94afdbe8a76e2677645c4dee6bdb3b3" datatype="html">
         <source>IUCN status</source>
-        <target/>
+        <target state="final">IUCN status</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">58</context>
@@ -2572,7 +2591,7 @@
       </trans-unit>
       <trans-unit id="f7b77c07f0f64b0f4946d066ccb7caf42f6d64f5" datatype="html">
         <source>New monitor</source>
-        <target/>
+        <target state="final">New monitor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2582,7 +2601,7 @@
       </trans-unit>
       <trans-unit id="d37e644a3c2fe4a97af5fc04c5ba23c50ca0d1bc" datatype="html">
         <source>Update monitor</source>
-        <target/>
+        <target state="final">Update monitor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -2592,7 +2611,7 @@
       </trans-unit>
       <trans-unit id="970d6446f3e343408a02266007c4782e5ffc18e2" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">17</context>
@@ -2602,17 +2621,17 @@
       </trans-unit>
       <trans-unit id="2f23d7732da6de204b25e720af0932539533f290" datatype="html">
         <source>Name is required</source>
-        <target/>
+        <target state="final">Name is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the name isn't supplied</note>
         <note priority="1" from="meaning">Monitor creation/edition</note>
       </trans-unit>
       <trans-unit id="f09fef617d6a9de0ef89d7e9a9582ebe111dd27e" datatype="html">
         <source>Monitor type</source>
-        <target/>
+        <target state="final">Monitor type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">23</context>
@@ -2622,7 +2641,7 @@
       </trans-unit>
       <trans-unit id="72638e600ce222ed8184c47260bbd68d362e693e" datatype="html">
         <source>External</source>
-        <target/>
+        <target state="final">External</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">27</context>
@@ -2631,7 +2650,7 @@
       </trans-unit>
       <trans-unit id="59d614de306c59782f5daa000ac64ab78986dfe3" datatype="html">
         <source>Government</source>
-        <target/>
+        <target state="final">Government</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">28</context>
@@ -2640,17 +2659,17 @@
       </trans-unit>
       <trans-unit id="f92e4776a0e55bc1f62e42a33492a06fcf1ef6f4" datatype="html">
         <source>Please select a type of monitor</source>
-        <target/>
+        <target state="final">Please select a type of monitor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">30</context>
         </context-group>
-        <note priority="1" from="description">Error message if the monitor type isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="description">Error message if the monitor type isn't supplied (the user will have to choose between some options)</note>
         <note priority="1" from="meaning">Monitor creation/edition</note>
       </trans-unit>
       <trans-unit id="56e1213f23dc45ca22b840ca175d09878c2fa327" datatype="html">
         <source>Country</source>
-        <target/>
+        <target state="final">Country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">34</context>
@@ -2660,17 +2679,17 @@
       </trans-unit>
       <trans-unit id="c474aac05e8433059be3ef9df630c75d919d91f0" datatype="html">
         <source>Organization</source>
-        <target/>
+        <target state="final">Organization</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">41</context>
         </context-group>
-        <note priority="1" from="description">Label for the organization&apos;s name field</note>
+        <note priority="1" from="description">Label for the organization's name field</note>
         <note priority="1" from="meaning">Monitor creation/edition</note>
       </trans-unit>
       <trans-unit id="2423329875b86c153e867d7b73ca084967a5ca4d" datatype="html">
         <source>Active</source>
-        <target/>
+        <target state="final">Active</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">46</context>
@@ -2680,7 +2699,7 @@
       </trans-unit>
       <trans-unit id="902d8c9a37cd5dbfbf804818d51018f57ee5ff6f" datatype="html">
         <source>New law</source>
-        <target/>
+        <target state="final">New law</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -2690,7 +2709,7 @@
       </trans-unit>
       <trans-unit id="f936a2051fc16836b5957df80ea4daf45dac6fb4" datatype="html">
         <source>Update law</source>
-        <target/>
+        <target state="final">Update law</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2700,7 +2719,7 @@
       </trans-unit>
       <trans-unit id="4ed0d6f64ddd3927b180003fed3cfec68eeca9fc" datatype="html">
         <source>Legal reference</source>
-        <target/>
+        <target state="final">Legal reference</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -2710,17 +2729,17 @@
       </trans-unit>
       <trans-unit id="1f5821b1de3e5287dd47d5afd1c73e8481f334a4" datatype="html">
         <source>Legal reference is required</source>
-        <target/>
+        <target state="final">Legal reference is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the legal reference isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the legal reference isn't supplied</note>
         <note priority="1" from="meaning">Law creation/edition</note>
       </trans-unit>
       <trans-unit id="5dee6b0be929a8b581a7d1e1dadb99163583707d" datatype="html">
         <source>Country</source>
-        <target/>
+        <target state="final">Country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -2730,17 +2749,17 @@
       </trans-unit>
       <trans-unit id="5909daed5b4040739fd19794fc9eb601db3840f7" datatype="html">
         <source>Please select a country</source>
-        <target/>
+        <target state="final">Please select a country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">26</context>
         </context-group>
-        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="description">Error message if the country isn't supplied (the user will have to choose between some options)</note>
         <note priority="1" from="meaning">Law creation/edition</note>
       </trans-unit>
       <trans-unit id="0ba722b8181589f48f6982c2e6289a3a7e638b30" datatype="html">
         <source>VPA indicator</source>
-        <target/>
+        <target state="final">VPA indicator</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">29</context>
@@ -2750,7 +2769,7 @@
       </trans-unit>
       <trans-unit id="da81d170cec9c56d085e1a83d72a75083fb34bde" datatype="html">
         <source>Legal penalty</source>
-        <target/>
+        <target state="final">Legal penalty</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -2760,7 +2779,7 @@
       </trans-unit>
       <trans-unit id="da0e191e3b5ce9a03ebf6935c7a3da8f1df39963" datatype="html">
         <source>New government</source>
-        <target/>
+        <target state="final">New government</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -2770,7 +2789,7 @@
       </trans-unit>
       <trans-unit id="d63b452dfa4a1be6a31c188edf56b946a9bc3a36" datatype="html">
         <source>Update government</source>
-        <target/>
+        <target state="final">Update government</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2780,7 +2799,7 @@
       </trans-unit>
       <trans-unit id="994f851a27e09e9b2eb725f832cc0d6406362b63" datatype="html">
         <source>Government entity</source>
-        <target/>
+        <target state="final">Government entity</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -2790,17 +2809,17 @@
       </trans-unit>
       <trans-unit id="d3a14f1a9f2eccb2b150c1a53d36ff3642f41664" datatype="html">
         <source>Government entity is required</source>
-        <target/>
+        <target state="final">Government entity is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the government entity isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the government entity isn't supplied</note>
         <note priority="1" from="meaning">Government creation/edition</note>
       </trans-unit>
       <trans-unit id="0b577ea470cf9239b9ee5a7f49e1648b38450413" datatype="html">
         <source>Country</source>
-        <target/>
+        <target state="final">Country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -2810,17 +2829,17 @@
       </trans-unit>
       <trans-unit id="f2fae309178d62c60d650f78ee2f5076fc48cb02" datatype="html">
         <source>Please select a country</source>
-        <target/>
+        <target state="final">Please select a country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">26</context>
         </context-group>
-        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to choose between serveral options)</note>
+        <note priority="1" from="description">Error message if the country isn't supplied (the user will have to choose between serveral options)</note>
         <note priority="1" from="meaning">Government creation/edition</note>
       </trans-unit>
       <trans-unit id="070870f728185c5169acfbd58382939274fcbc27" datatype="html">
         <source>Details</source>
-        <target/>
+        <target state="final">Details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">30</context>
@@ -2832,7 +2851,9 @@
         <source>
       New government unit
     </source>
-        <target/>
+        <target state="final">
+      New government unit
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2841,7 +2862,7 @@
       </trans-unit>
       <trans-unit id="7375730a696290da1ac4a1b41aa1807227704d38" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2851,7 +2872,7 @@
       </trans-unit>
       <trans-unit id="a77615221336090843bf4217630174cf0aaadcb2" datatype="html">
         <source>Details</source>
-        <target/>
+        <target state="final">Details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2861,7 +2882,7 @@
       </trans-unit>
       <trans-unit id="77d0d5ee531ac0867be1b0ce429d9f23314fa4cd" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2871,7 +2892,7 @@
       </trans-unit>
       <trans-unit id="648fe89999cc59abebc2ff5e62c7f4f619bf456e" datatype="html">
         <source>Governments</source>
-        <target/>
+        <target state="final">Governments</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2882,7 +2903,9 @@
         <source>
       New Category
     </source>
-        <target/>
+        <target state="final">
+      New Category
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2891,7 +2914,7 @@
       </trans-unit>
       <trans-unit id="3e44dbcc81d17832a393250e494929e0b6382c0b" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2901,7 +2924,7 @@
       </trans-unit>
       <trans-unit id="a0d9d59763903ebae40d4d8e3b62ffbf5d3d717a" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2911,7 +2934,7 @@
       </trans-unit>
       <trans-unit id="04201f9d27abd7d6f58a4328ab98063ce1072006" datatype="html">
         <source>Categories</source>
-        <target/>
+        <target state="final">Categories</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2920,7 +2943,7 @@
       </trans-unit>
       <trans-unit id="daf4f4c015509bb67eb6d6d726b256a8615d7758" datatype="html">
         <source>Open Timber Portal</source>
-        <target/>
+        <target state="final">Open Timber Portal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2929,7 +2952,7 @@
       </trans-unit>
       <trans-unit id="3fdc751b264ca9998e1542fcf5794e274cd56344" datatype="html">
         <source>Log out</source>
-        <target/>
+        <target state="final">Log out</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -2938,7 +2961,7 @@
       </trans-unit>
       <trans-unit id="791b002647a2f49818c508b2860c68e7f23b17b6" datatype="html">
         <source>My OTP</source>
-        <target/>
+        <target state="final">My OTP</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2952,7 +2975,7 @@
       </trans-unit>
       <trans-unit id="831b9ec431d2a93a412ef510bd1fae36c721400a" datatype="html">
         <source>Observations</source>
-        <target/>
+        <target state="final">Observations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2966,7 +2989,7 @@
       </trans-unit>
       <trans-unit id="dbe0f319ddd1cc5c17d1a4e9585996c89fd2d05c" datatype="html">
         <source>Observation fields</source>
-        <target/>
+        <target state="final">Observation fields</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -2976,7 +2999,7 @@
       </trans-unit>
       <trans-unit id="74b0fac259eeefc9f20aeb6a1bd08931012390c9" datatype="html">
         <source>Users</source>
-        <target/>
+        <target state="final">Users</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -2990,7 +3013,7 @@
       </trans-unit>
       <trans-unit id="1ae1df848c628a7a059c1ff57be3449ecacc5c91" datatype="html">
         <source>New user</source>
-        <target/>
+        <target state="final">New user</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -3000,7 +3023,7 @@
       </trans-unit>
       <trans-unit id="7663160100ebcc9a117c8cb206b0624e172f89c9" datatype="html">
         <source>Update user</source>
-        <target/>
+        <target state="final">Update user</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -3010,7 +3033,7 @@
       </trans-unit>
       <trans-unit id="4b43d07d0171b690cd5d541d649389af16378912" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">21</context>
@@ -3020,17 +3043,17 @@
       </trans-unit>
       <trans-unit id="a8077802820f0bac578cee128f3146719d87c292" datatype="html">
         <source>Name is required</source>
-        <target/>
+        <target state="final">Name is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">23</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the name isn't supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="9531f868dd03aac6f0d2687eed93dd57d4fcb910" datatype="html">
         <source>Username</source>
-        <target/>
+        <target state="final">Username</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">27</context>
@@ -3040,17 +3063,17 @@
       </trans-unit>
       <trans-unit id="517d85ca7650f90dd91f14a4e3ecffab28967926" datatype="html">
         <source>Username is required</source>
-        <target/>
+        <target state="final">Username is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">29</context>
         </context-group>
-        <note priority="1" from="description">Error message if the username/nickname isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the username/nickname isn't supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="62dc5076c0fe3427ba6a0ed17008cecea393c1a1" datatype="html">
         <source>Email</source>
-        <target/>
+        <target state="final">Email</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -3060,27 +3083,27 @@
       </trans-unit>
       <trans-unit id="6c46fe594e7a68965a97b78ef5e22859e5781d68" datatype="html">
         <source>Email is required</source>
-        <target/>
+        <target state="final">Email is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">35</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the email isn't supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="ad967d9088a765aebf92c3116b8f5398d6e2de09" datatype="html">
         <source>Please enter an email address</source>
-        <target/>
+        <target state="final">Please enter an email address</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">36</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
+        <note priority="1" from="description">Error message if the email isn't valid</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="9515b8c96b948fff69c74667be3248115e876ed2" datatype="html">
         <source>Institution</source>
-        <target/>
+        <target state="final">Institution</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">40</context>
@@ -3090,7 +3113,7 @@
       </trans-unit>
       <trans-unit id="e9959215c7e71edde620b01439f5ffbecd5d2b27" datatype="html">
         <source>Country</source>
-        <target/>
+        <target state="final">Country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">45</context>
@@ -3100,7 +3123,7 @@
       </trans-unit>
       <trans-unit id="4fe21c99a9c7a18ae378c3e0958b146f21e56ad9" datatype="html">
         <source>Password</source>
-        <target/>
+        <target state="final">Password</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">53</context>
@@ -3110,17 +3133,17 @@
       </trans-unit>
       <trans-unit id="795dfb8a206622b513661b3ecdb0e697e4cd1e0f" datatype="html">
         <source>Password is required</source>
-        <target/>
+        <target state="final">Password is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">55</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the password isn't supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="0decdfdf829ae2fdedebac57ce24f1cbdca085fb" datatype="html">
         <source>Confirm your password</source>
-        <target/>
+        <target state="final">Confirm your password</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">59</context>
@@ -3130,27 +3153,27 @@
       </trans-unit>
       <trans-unit id="8c0add49e7d050ab76f5f1bf53b43410f95d73bb" datatype="html">
         <source>Please confirm your password</source>
-        <target/>
+        <target state="final">Please confirm your password</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">61</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password confirmation isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the password confirmation isn't supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="03a6fc721e7fcdae64bb5982a0674ca3c45d1870" datatype="html">
-        <source>Password values don&apos;t not coincide</source>
-        <target/>
+        <source>Password values don't not coincide</source>
+        <target state="final">Password values don't not coincide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">62</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password and its confirmation don&apos;t coincide&apos;</note>
+        <note priority="1" from="description">Error message if the password and its confirmation don't coincide'</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="d0003e833df402846f87694894de69a744609fcb" datatype="html">
         <source>Permissions</source>
-        <target/>
+        <target state="final">Permissions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">67</context>
@@ -3160,7 +3183,7 @@
       </trans-unit>
       <trans-unit id="408cb6073e60c5d966296a3207fc596adca75e01" datatype="html">
         <source>Admin</source>
-        <target/>
+        <target state="final">Admin</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">69</context>
@@ -3169,7 +3192,7 @@
       </trans-unit>
       <trans-unit id="e652540fcb10505228ef38a3a9790a94a3728fc5" datatype="html">
         <source>NGO</source>
-        <target/>
+        <target state="final">NGO</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">70</context>
@@ -3178,7 +3201,7 @@
       </trans-unit>
       <trans-unit id="f3dba5732cb548f04fc8b4727e3568f5169956f1" datatype="html">
         <source>New observation</source>
-        <target/>
+        <target state="final">New observation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -3188,17 +3211,17 @@
       </trans-unit>
       <trans-unit id="a01fcf88689d79ed060dce1f72b5adeaa7b46faf" datatype="html">
         <source>Please select a observation type</source>
-        <target/>
+        <target state="final">Please select a observation type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the type isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the type isn't supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="5c50b2cbccccfacca324cac86084eea6dca8a9b6" datatype="html">
         <source>Categories</source>
-        <target/>
+        <target state="final">Categories</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -3207,12 +3230,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">16</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="c5c1ede612299da54bd1911c2afff91164c6d67d" datatype="html">
         <source>Sub-categories</source>
-        <target/>
+        <target state="final">Sub-categories</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -3221,12 +3244,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="c61f95bc9d62cf3b27e0de4d2ccafdec84025876" datatype="html">
         <source>Species</source>
-        <target/>
+        <target state="final">Species</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -3235,12 +3258,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="cbaa4c8a4a07ae77d139bdffb581d89f19f40380" datatype="html">
         <source>Countries</source>
-        <target/>
+        <target state="final">Countries</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -3249,12 +3272,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="cc1f09ccc4db74d6d42f5dd647f061d86d857c60" datatype="html">
         <source>Governments</source>
-        <target/>
+        <target state="final">Governments</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">7</context>
@@ -3263,12 +3286,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">20</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="d46cab8761b81984adf73aa599930ae8b5a4c1ed" datatype="html">
         <source>Monitors</source>
-        <target/>
+        <target state="final">Monitors</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -3277,12 +3300,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">22</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="8617e06849d42c1b655ebff3a0f213a0b7c5e6f3" datatype="html">
         <source>Laws</source>
-        <target/>
+        <target state="final">Laws</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -3291,14 +3314,16 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">23</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="1a6f616703d75ae22ef5f11706c3815ca04888c5" datatype="html">
         <source>
         New user
       </source>
-        <target/>
+        <target state="final">
+        New user
+      </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -3307,7 +3332,7 @@
       </trans-unit>
       <trans-unit id="408d18faf367209fe427e59b979f2b44901e0e7c" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -3317,7 +3342,7 @@
       </trans-unit>
       <trans-unit id="0a15a5d859d810d87d241e8c1e0320a6bf4eaab6" datatype="html">
         <source>Username</source>
-        <target/>
+        <target state="final">Username</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -3327,7 +3352,7 @@
       </trans-unit>
       <trans-unit id="d9a3cb1133a129319296a62a6592ccb4633c37ad" datatype="html">
         <source>Email</source>
-        <target/>
+        <target state="final">Email</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -3337,7 +3362,7 @@
       </trans-unit>
       <trans-unit id="7ed96443291c57e0eef0a6f1adcbf1a3013449a4" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -3347,7 +3372,7 @@
       </trans-unit>
       <trans-unit id="4d13a9cd5ed3dcee0eab22cb25198d43886942be" datatype="html">
         <source>Users</source>
-        <target/>
+        <target state="final">Users</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -3356,7 +3381,7 @@
       </trans-unit>
       <trans-unit id="d8ce6578695232c810274be36568aee8217d9e12" datatype="html">
         <source>Fields</source>
-        <target/>
+        <target state="final">Fields</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -3366,7 +3391,7 @@
       </trans-unit>
       <trans-unit id="099668cc93fe681254739694dc7d662069a8b659" datatype="html">
         <source>Register</source>
-        <target/>
+        <target state="final">Register</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">2</context>
@@ -3376,7 +3401,7 @@
       </trans-unit>
       <trans-unit id="245198374604dd2866e843ca1411b3b5bee26b4b" datatype="html">
         <source>Name</source>
-        <target/>
+        <target state="final">Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -3386,17 +3411,17 @@
       </trans-unit>
       <trans-unit id="455490d6079d0287a4dd8a51d0087c7df48e018c" datatype="html">
         <source>Name is required</source>
-        <target/>
+        <target state="final">Name is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">8</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the name isn't supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="077471e569722451975586da916fe91f1eede0f0" datatype="html">
         <source>Username</source>
-        <target/>
+        <target state="final">Username</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -3406,17 +3431,17 @@
       </trans-unit>
       <trans-unit id="89434c6c32783ce50a9818d919b0cfcf1883dfe7" datatype="html">
         <source>Username is required</source>
-        <target/>
+        <target state="final">Username is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">13</context>
         </context-group>
-        <note priority="1" from="description">Error message if the username/nickname isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the username/nickname isn't supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="67e26ffa056d34f8f5c34cfe01af731f4667d420" datatype="html">
         <source>Institution</source>
-        <target/>
+        <target state="final">Institution</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -3426,7 +3451,7 @@
       </trans-unit>
       <trans-unit id="ff8c80b065ad5802b5d2539e41ec7bfa14c65646" datatype="html">
         <source>Country</source>
-        <target/>
+        <target state="final">Country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">20</context>
@@ -3436,7 +3461,7 @@
       </trans-unit>
       <trans-unit id="0e420cff0712db35b0fb636b9c7b73182307ee48" datatype="html">
         <source>Email</source>
-        <target/>
+        <target state="final">Email</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">26</context>
@@ -3446,27 +3471,27 @@
       </trans-unit>
       <trans-unit id="e3e6b8f98dd44b6c1cb5834713b771004b15369a" datatype="html">
         <source>Email is required</source>
-        <target/>
+        <target state="final">Email is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">28</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the email isn't supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="0852bccb9acdfc7c24ea9f89f997812e20c5f66c" datatype="html">
         <source>Please enter an email address</source>
-        <target/>
+        <target state="final">Please enter an email address</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">29</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
+        <note priority="1" from="description">Error message if the email isn't valid</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="8878633ec07d9bfe29eaf51cf501e87fe3df588f" datatype="html">
         <source>Password</source>
-        <target/>
+        <target state="final">Password</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">32</context>
@@ -3476,17 +3501,17 @@
       </trans-unit>
       <trans-unit id="37259b13dc58cf4ece14d58b0e3c3dc883105168" datatype="html">
         <source>Password is required</source>
-        <target/>
+        <target state="final">Password is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the password isn't supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="87d9a4f470c63e0b8bfe7279223532e87adf6f08" datatype="html">
         <source>Confirm your password</source>
-        <target/>
+        <target state="final">Confirm your password</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -3496,27 +3521,27 @@
       </trans-unit>
       <trans-unit id="a6f6372f4dd465f68c31293774b454b477bdc918" datatype="html">
         <source>Please confirm your password</source>
-        <target/>
+        <target state="final">Please confirm your password</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">39</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password confirmation isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the password confirmation isn't supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="c45bce7d5bebd3886fa2ec661b234da55c062f54" datatype="html">
-        <source>Password values don&apos;t not coincide</source>
-        <target/>
+        <source>Password values don't not coincide</source>
+        <target state="final">Password values don't not coincide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">40</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password and it&apos;s confirmation don&apos;t coincide</note>
+        <note priority="1" from="description">Error message if the password and it's confirmation don't coincide</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="6765b4c916060f6bc42d9bb69e80377dbcb5e4e9" datatype="html">
         <source>Login</source>
-        <target/>
+        <target state="final">Login</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">43</context>
@@ -3529,7 +3554,7 @@
       </trans-unit>
       <trans-unit id="cfc2f436ec2beffb042e7511a73c89c372e86a6c" datatype="html">
         <source>Register</source>
-        <target/>
+        <target state="final">Register</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">44</context>
@@ -3542,7 +3567,7 @@
       </trans-unit>
       <trans-unit id="229210ea5aded39aacf9e7d79e1658b32ca104f6" datatype="html">
         <source>New observation</source>
-        <target/>
+        <target state="final">New observation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -3551,7 +3576,7 @@
       </trans-unit>
       <trans-unit id="00c200adab3e41e35d1e06d42d847d17f747e71c" datatype="html">
         <source>Date</source>
-        <target/>
+        <target state="final">Date</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -3561,7 +3586,7 @@
       </trans-unit>
       <trans-unit id="645872c938ac5195a4906afa0f6118cc9b52771b" datatype="html">
         <source>Country</source>
-        <target/>
+        <target state="final">Country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">17</context>
@@ -3571,7 +3596,7 @@
       </trans-unit>
       <trans-unit id="0ea6d0e3424fa1ffdb64a3b98a9815c98b595435" datatype="html">
         <source>Operator</source>
-        <target/>
+        <target state="final">Operator</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">18</context>
@@ -3581,7 +3606,7 @@
       </trans-unit>
       <trans-unit id="be0139f1cf8e5feab4a5b691287c7c0d9c74fc86" datatype="html">
         <source>Category</source>
-        <target/>
+        <target state="final">Category</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">19</context>
@@ -3591,7 +3616,7 @@
       </trans-unit>
       <trans-unit id="788391ad82018522ef4162b47fb8e81f00217bd6" datatype="html">
         <source>Observation</source>
-        <target/>
+        <target state="final">Observation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">20</context>
@@ -3601,7 +3626,7 @@
       </trans-unit>
       <trans-unit id="a8a36702a876525737fdbabb99b6f5bceac167a6" datatype="html">
         <source>Severity</source>
-        <target/>
+        <target state="final">Severity</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">21</context>
@@ -3611,7 +3636,7 @@
       </trans-unit>
       <trans-unit id="f988c370ec8c750c0b84a0c412e440d53cee631d" datatype="html">
         <source>Actions</source>
-        <target/>
+        <target state="final">Actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -3621,7 +3646,7 @@
       </trans-unit>
       <trans-unit id="4b8c7b2a240e413c2c1eb4a69abf371ac5c5742e" datatype="html">
         <source>Observations</source>
-        <target/>
+        <target state="final">Observations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -3630,7 +3655,7 @@
       </trans-unit>
       <trans-unit id="8d68caf60e263e599e86d21321e1939323492821" datatype="html">
         <source>Login</source>
-        <target/>
+        <target state="final">Login</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -3640,7 +3665,7 @@
       </trans-unit>
       <trans-unit id="4d8a562e319cebae08fb094877d11d80be7ed87d" datatype="html">
         <source>Email</source>
-        <target/>
+        <target state="final">Email</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -3650,27 +3675,27 @@
       </trans-unit>
       <trans-unit id="4c7f617fdaf91a9d45c52aa985e99304538bf140" datatype="html">
         <source>Email is required</source>
-        <target/>
+        <target state="final">Email is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">8</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the email isn't supplied</note>
         <note priority="1" from="meaning">Login page</note>
       </trans-unit>
       <trans-unit id="dec04191c54f62c23d2012fafcb24c07c198ba58" datatype="html">
         <source>Please enter an email address</source>
-        <target/>
+        <target state="final">Please enter an email address</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">9</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
+        <note priority="1" from="description">Error message if the email isn't valid</note>
         <note priority="1" from="meaning">Login page</note>
       </trans-unit>
       <trans-unit id="69a2b7b2e465e58e7df02173034ee5f9c332ad70" datatype="html">
         <source>Password</source>
-        <target/>
+        <target state="final">Password</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -3680,12 +3705,12 @@
       </trans-unit>
       <trans-unit id="ee6940c10dba8bb8734ddb805ccc75c02f0ace8b" datatype="html">
         <source>Password is required</source>
-        <target/>
+        <target state="final">Password is required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">14</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
+        <note priority="1" from="description">Error message if the password isn't supplied</note>
         <note priority="1" from="meaning">Login page</note>
       </trans-unit>
     </body>

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="aa112aafab99fca60e770e78dcc5d3c27f8ec4f4" datatype="html">
+        <source>404. Page not found</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="b66a22023a03f8985f17e59380711f3b5a099e53" datatype="html">
+        <source>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="641c31c001d58979956c8cb20082d85f6d8ae541" datatype="html">
+        <source>Go to my OTP</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ef691d3c76b2fa1584de7943391598624e64e1bc" datatype="html">
+        <source>Go to login page</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -80,6 +80,34 @@
         <note priority="1" from="description">Next page button</note>
         <note priority="1" from="meaning">Table paginator</note>
       </trans-unit>
+      <trans-unit id="65701e62f4eb6566c62a6088842f6f95fa8ef48e" datatype="html">
+        <source>Organization profile</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;My OTP&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="fb32420414820f45d127a9e6f51985800d930fbb" datatype="html">
+        <source>My observations</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;My OTP&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
       <trans-unit id="fa9b7116761f013fe509c7646dee9d1e9c3cc31a" datatype="html">
         <source>Name of the organization</source>
         <target/>
@@ -1692,6 +1720,42 @@
         <note priority="1" from="description">Label for the details field</note>
         <note priority="1" from="meaning">Operator sub-category creation/edition</note>
       </trans-unit>
+      <trans-unit id="ad9508c67f58f44fd3b4d73925e50fa53de76fb7" datatype="html">
+        <source>Operators</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/subcategories.component.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Sub-categories&apos; list page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="cefad27e0f05695d2e7d84403f5370fa0ac85c5f" datatype="html">
+        <source>Governance</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/subcategories.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Sub-categories&apos; list page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
       <trans-unit id="85afe36487fab2e70904c3d796f0ea2f7a5a90a9" datatype="html">
         <source>New category</source>
         <target/>
@@ -2844,6 +2908,58 @@
         </context-group>
         <note priority="1" from="description">Log out button</note>
       </trans-unit>
+      <trans-unit id="791b002647a2f49818c508b2860c68e7f23b17b6" datatype="html">
+        <source>My OTP</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <note priority="1" from="description">Main navigation menu (desktop)</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="831b9ec431d2a93a412ef510bd1fae36c721400a" datatype="html">
+        <source>Observations</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <note priority="1" from="description">Main navigation menu (desktop)</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="dbe0f319ddd1cc5c17d1a4e9585996c89fd2d05c" datatype="html">
+        <source>Observation fields</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Main navigation menu (desktop)</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="74b0fac259eeefc9f20aeb6a1bd08931012390c9" datatype="html">
+        <source>Users</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Main navigation menu (desktop)</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
       <trans-unit id="1ae1df848c628a7a059c1ff57be3449ecacc5c91" datatype="html">
         <source>New user</source>
         <target/>
@@ -3052,6 +3168,104 @@
         <note priority="1" from="description">Error message if the type isn&apos;t supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
+      <trans-unit id="5c50b2cbccccfacca324cac86084eea6dca8a9b6" datatype="html">
+        <source>Categories</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="c5c1ede612299da54bd1911c2afff91164c6d67d" datatype="html">
+        <source>Sub-categories</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="c61f95bc9d62cf3b27e0de4d2ccafdec84025876" datatype="html">
+        <source>Species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="cbaa4c8a4a07ae77d139bdffb581d89f19f40380" datatype="html">
+        <source>Countries</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="cc1f09ccc4db74d6d42f5dd647f061d86d857c60" datatype="html">
+        <source>Governments</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="d46cab8761b81984adf73aa599930ae8b5a4c1ed" datatype="html">
+        <source>Monitors</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="8617e06849d42c1b655ebff3a0f213a0b7c5e6f3" datatype="html">
+        <source>Laws</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
       <trans-unit id="1a6f616703d75ae22ef5f11706c3815ca04888c5" datatype="html">
         <source>
         New user
@@ -3110,42 +3324,17 @@
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">10</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
-          <context context-type="linenumber">4</context>
-        </context-group>
         <note priority="1" from="description">Caption for the table which lists the users</note>
       </trans-unit>
-      <trans-unit id="30e10cd5f105624805db7f96287a3b7edd5fff9c" datatype="html">
-        <source>My OTP</source>
-        <target/>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
-          <context context-type="linenumber">1</context>
-        </context-group>
-        <note priority="1" from="description">My OTP menu option</note>
-      </trans-unit>
-      <trans-unit id="4b8c7b2a240e413c2c1eb4a69abf371ac5c5742e" datatype="html">
-        <source>Observations</source>
-        <target/>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
-          <context context-type="linenumber">13</context>
-        </context-group>
-        <note priority="1" from="description">Observations menu option</note>
-      </trans-unit>
-      <trans-unit id="faf74edc4404313eeb85945cc1a99cc4ff4a6fd6" datatype="html">
+      <trans-unit id="d8ce6578695232c810274be36568aee8217d9e12" datatype="html">
         <source>Fields</source>
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
           <context context-type="linenumber">3</context>
         </context-group>
-        <note priority="1" from="description">Fields menu option</note>
+        <note priority="1" from="description">Main navigation menu (mobile)</note>
+        <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="099668cc93fe681254739694dc7d662069a8b659" datatype="html">
         <source>Register</source>
@@ -3401,6 +3590,15 @@
         </context-group>
         <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
         <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="4b8c7b2a240e413c2c1eb4a69abf371ac5c5742e" datatype="html">
+        <source>Observations</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the observations</note>
       </trans-unit>
       <trans-unit id="8d68caf60e263e599e86d21321e1939323492821" datatype="html">
         <source>Login</source>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -60,12 +60,40 @@
         </context-group>
         <note priority="1" from="description">Complementary caption information</note>
       </trans-unit>
+      <trans-unit id="6e0fa4af5418a615a1a09c67e32682e6b69c0f79" datatype="html">
+        <source>ascendent</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Sort order of the table</note>
+      </trans-unit>
+      <trans-unit id="547d6a7a6de920a2aefc34eeec1b9fc3d393bbb8" datatype="html">
+        <source>descendent</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Sort order of the table</note>
+      </trans-unit>
+      <trans-unit id="6219cbb729e72ee75b30c2ce46d7959d1d09aa8d" datatype="html">
+        <source>Page</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <note priority="1" from="description">Page of a table</note>
+        <note priority="1" from="meaning">Table paginator</note>
+      </trans-unit>
       <trans-unit id="e3706b34167ca5b613defa8be3a5d4c6316741e5" datatype="html">
         <source>Previous</source>
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">51</context>
         </context-group>
         <note priority="1" from="description">Previous page button</note>
         <note priority="1" from="meaning">Table paginator</note>
@@ -75,7 +103,7 @@
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">61</context>
         </context-group>
         <note priority="1" from="description">Next page button</note>
         <note priority="1" from="meaning">Table paginator</note>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="aa112aafab99fca60e770e78dcc5d3c27f8ec4f4" datatype="html">
+        <source>404. Page not found</source>
+        <target>404. Page indisponible</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="b66a22023a03f8985f17e59380711f3b5a099e53" datatype="html">
+        <source>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</source>
+        <target>Cette page est introuvable, a été renommée ou est temporairement indisponible.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="641c31c001d58979956c8cb20082d85f6d8ae541" datatype="html">
+        <source>Go to my OTP</source>
+        <target>Aller à mon OTP</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ef691d3c76b2fa1584de7943391598624e64e1bc" datatype="html">
+        <source>Go to login page</source>
+        <target>Se connecter</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -2,37 +2,3465 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
-      <trans-unit id="aa112aafab99fca60e770e78dcc5d3c27f8ec4f4" datatype="html">
+      <trans-unit id="4f7091778907548985c8b4a592fa68e0f4c3368e" datatype="html">
         <source>404. Page not found</source>
         <target>404. Page indisponible</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">3</context>
         </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">404 page</note>
       </trans-unit>
-      <trans-unit id="b66a22023a03f8985f17e59380711f3b5a099e53" datatype="html">
+      <trans-unit id="7b899c5c53c6d77238cbc42d49e17dcac27ba085" datatype="html">
         <source>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</source>
         <target>Cette page est introuvable, a été renommée ou est temporairement indisponible.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">4</context>
         </context-group>
+        <note priority="1" from="description">Description of the error</note>
+        <note priority="1" from="meaning">404 page</note>
       </trans-unit>
-      <trans-unit id="641c31c001d58979956c8cb20082d85f6d8ae541" datatype="html">
+      <trans-unit id="7fb2c801d64dddc6287ab33765a74490ff471cc3" datatype="html">
         <source>Go to my OTP</source>
         <target>Aller à mon OTP</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">5</context>
         </context-group>
+        <note priority="1" from="description">Button to suggest the user to go to the &apos;My OTP&apos; page</note>
+        <note priority="1" from="meaning">404 page</note>
       </trans-unit>
-      <trans-unit id="ef691d3c76b2fa1584de7943391598624e64e1bc" datatype="html">
+      <trans-unit id="e32a02d7bc279823ef3a51428092c600cc181612" datatype="html">
         <source>Go to login page</source>
         <target>Se connecter</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">6</context>
         </context-group>
+        <note priority="1" from="description">Button to suggest the user to go to the login page</note>
+        <note priority="1" from="meaning">404 page</note>
+      </trans-unit>
+      <trans-unit id="bebaee9b83b435336940bd0f6bbecbefb8b81470" datatype="html">
+        <source>Undefined table</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Default caption for the tables</note>
+      </trans-unit>
+      <trans-unit id="5a97a400bac7feaf727c8bf556aaef97e34d82ea" datatype="html">
+        <source>, sorted by</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Complementary caption information</note>
+      </trans-unit>
+      <trans-unit id="e3706b34167ca5b613defa8be3a5d4c6316741e5" datatype="html">
+        <source>Previous</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <note priority="1" from="description">Previous page button</note>
+        <note priority="1" from="meaning">Table paginator</note>
+      </trans-unit>
+      <trans-unit id="274039dd3b5e706302cf2c3c433ea450bdd49703" datatype="html">
+        <source>Next</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/table/table.component.ts</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <note priority="1" from="description">Next page button</note>
+        <note priority="1" from="meaning">Table paginator</note>
+      </trans-unit>
+      <trans-unit id="fa9b7116761f013fe509c7646dee9d1e9c3cc31a" datatype="html">
+        <source>Name of the organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field (name of the organization)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="d5035c69fba58edb578fe982eb8a03175f494319" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name of the organization isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="43ecccfbfb54901f26ce0d24939dbfff4315e553" datatype="html">
+        <source>Address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Label for the address field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="5aa48f8e4b18078364f9fa7af5fd13b8a4ade535" datatype="html">
+        <source>Address is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the address isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="7a19016a7b3167d2713f39b788e5e7d80f3f737d" datatype="html">
+        <source>Contact information (General information)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="1bb6270fc515c0526e262c35cf24ba9cf34bf917" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+        <note priority="1" from="description">Label for the contact&apos;s name field (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="caff929db9ef4d149aee1cc57926540ee74b88db" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <note priority="1" from="description">Label for the contact&apos;s email field (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="d642a03eb15d9e04e7577d51323276179b7324e2" datatype="html">
+        <source>Email is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the contact email isn&apos;t supplied (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="f5de8925e983f8662cf13f3f03d94643ba8eee8c" datatype="html">
+        <source>Please enter an email address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the contact email isn&apos;t valid (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="ddabada26b82beaa67cb0b3fdcf54a282921afe1" datatype="html">
+        <source>Phone number</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <note priority="1" from="description">Label for the contact&apos;s phone number field (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="178268700e3527de634d28f7e397b10a5cecd7a0" datatype="html">
+        <source>Phone number is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the contact phone number isn&apos;t supplied (general information)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="15681d9d8184e095004288f60aace675ddc8e930" datatype="html">
+        <source>Contact information (For inquiries on data uploaded)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="8056edf01468679e6f762fece7279fd0a31c0474" datatype="html">
+        <source>Type of organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <note priority="1" from="description">Label for the type of organization field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="286a22f1d01b750cc5f9fe1fc0053494c4fb9411" datatype="html">
+        <source>Non governmental organization (NGO)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="8ae0be16277ef1c4b8c160c21c709addaafdf4b7" datatype="html">
+        <source>Academic</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="6de33973fba79ddbbc39cf39c100d1818d363ab1" datatype="html">
+        <source>Research Institute</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="9afb9078f854a9c32cdf55d49309ef19b5b6338d" datatype="html">
+        <source>Private company</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">80</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="c2a9de3714f5767b174d0424bc8abe2dc37acc41" datatype="html">
+        <source>Other</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+        <note priority="1" from="description">Type of organization</note>
+      </trans-unit>
+      <trans-unit id="77ddb384bda36384bf19fd82da34668638cd1237" datatype="html">
+        <source>Please select a type of organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the type of organization isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="c1351de8b39808e0f027828afbaf48eafbefb36c" datatype="html">
+        <source>Please specify:</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">104</context>
+        </context-group>
+        <note priority="1" from="description">Label of an additional field where the user is asked to specify/detail a previous field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="2c67985932f0441af58f46be0b153bd30f39c5d9" datatype="html">
+        <source>Type of organization is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">89</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the &apos;more specific&apos; type of organization field isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="820d568fbf0cde2dd31e9f7d95fd4496a201189f" datatype="html">
+        <source>Type of monitoring organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <note priority="1" from="description">Label for the type of monitoring organization field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="b06f369749b6fb40f9373986c261c239898aae3e" datatype="html">
+        <source>Mandated</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <note priority="1" from="description">type of monitoring organization</note>
+      </trans-unit>
+      <trans-unit id="f06a9f71b004266aee89162657ea1c86d1315553" datatype="html">
+        <source>Semi mandated</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">type of monitoring organization</note>
+      </trans-unit>
+      <trans-unit id="b56d7b02a4200f20c0f4889025281c8280e88f09" datatype="html">
+        <source>Non-mandated (external)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+        <note priority="1" from="description">type of monitoring organization</note>
+      </trans-unit>
+      <trans-unit id="683a0fe8c12c2ce250c6dd5194f545ae7748db21" datatype="html">
+        <source>Please select a type of monitoring organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">100</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the type of monitoring organization isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="ea6416e29a89c5c714e69d898daba32eb41b698a" datatype="html">
+        <source>Type of monitoring organization is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the &apos;more specific&apos; type of monitoring organization field isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="3f26932174625c41427110ccc2226e504f5c6fbd" datatype="html">
+        <source>Current independent monitoring project</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">110</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="bf8439c857331fc455d3d031b6e2c60acf4389a9" datatype="html">
+        <source>Project title</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">115</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">199</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">244</context>
+        </context-group>
+        <note priority="1" from="description">Label for the project title field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="b2140291449def6677aa53569b3c48d84a56c20b" datatype="html">
+        <source>Project title is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">117</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the project title isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="8c78e20470679aab2f535754cbe129b99bb2df87" datatype="html">
+        <source>Lead organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">121</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">204</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">249</context>
+        </context-group>
+        <note priority="1" from="description">Label for the lead organization field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="e4f0576d34d9e84843eacd1a69357b464c2778bd" datatype="html">
+        <source>Lead organization is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">123</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the lead organization of a project isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="7fdfd037df64f59dcc2e76a327cd2706aa70dd5d" datatype="html">
+        <source>Start date</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">254</context>
+        </context-group>
+        <note priority="1" from="description">Label for the start date field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="3aba988d313ad1e91e0422e04026526c026e4344" datatype="html">
+        <source>Start date is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">129</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the start date of a project isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="a4cecf67712a605f7eb501374d3265fd12478cec" datatype="html">
+        <source>Project duration (years)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">133</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">214</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">259</context>
+        </context-group>
+        <note priority="1" from="description">Label for the duration in years field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="32acf484fd94a7bbb5192328b88f846d21f96fb3" datatype="html">
+        <source>Project duration is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">135</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the duration in years of a project isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="8a56af3ab6bb5ee118d69244fac33c11ab40a24b" datatype="html">
+        <source>Donor(s)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">139</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">219</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">264</context>
+        </context-group>
+        <note priority="1" from="description">Label for the donor(s) field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="d1be0cb8729481903a941dcc95235e5df34d1144" datatype="html">
+        <source>Donor(s) is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">141</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the donor(s) isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="6fd3fac713c24d0b1eb41ae210a92956dc47e067" datatype="html">
+        <source>Project website</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">145</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">224</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">269</context>
+        </context-group>
+        <note priority="1" from="description">Label for the website URL field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="61db125afe28f6cda94785420bbad6344cd6db25" datatype="html">
+        <source>Additional information on status, progress, etc.</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">150</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">229</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">274</context>
+        </context-group>
+        <note priority="1" from="description">Label for the additional information field (of a project)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="49819b177c45f46e71178ef87bc2888c67948703" datatype="html">
+        <source>Website link</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">161</context>
+        </context-group>
+        <note priority="1" from="description">Label for the website URL field (of the organization)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="dfc9e62e50d1da01fa8fd0b6b7bcc02a6816d784" datatype="html">
+        <source>Organisation’s mission (max 250 characters)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+        <note priority="1" from="description">Label for the organization&apos;s mission field (with a limit of 250 chars)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="e132818042799ae0d6af75d59ecfe7ad2997a9c5" datatype="html">
+        <source>You exceed the maximum number of characters</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">168</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">174</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the organization&apos;s mission exceeds 250 chars</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="6bf5e59e896974c50b48e83196c5cf1b334791cb" datatype="html">
+        <source>Quality control (max 500 characters)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">172</context>
+        </context-group>
+        <note priority="1" from="description">Label for the quality control process field (with a limit of 500 chars)</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="9714e9ae169a4c3cd16f982682d05002706c3e75" datatype="html">
+        <source>Geographical scope of work</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <note priority="1" from="description">Label for the organization&apos;s geographical scope field</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="c7ec8a666155407083e0df211e21f1bddc5b5304" datatype="html">
+        <source>Sub-national</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">180</context>
+        </context-group>
+        <note priority="1" from="description">Geographical scope of an organization</note>
+      </trans-unit>
+      <trans-unit id="4ebd5411731ecbd28a246b00fbe62d5e76356d36" datatype="html">
+        <source>National</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">181</context>
+        </context-group>
+        <note priority="1" from="description">Geographical scope of an organization</note>
+      </trans-unit>
+      <trans-unit id="cb683c4a7564df4ad793eedad2a5ac342ecf5c12" datatype="html">
+        <source>International</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">182</context>
+        </context-group>
+        <note priority="1" from="description">Geographical scope of an organization</note>
+      </trans-unit>
+      <trans-unit id="d3cbd7eedb32d830d50c4ca6e0f2440b00af4c6c" datatype="html">
+        <source>Project 1</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">194</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="c518f75c849d225f2ca6141925c505dd9606ec2e" datatype="html">
+        <source>Project 2</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">239</context>
+        </context-group>
+        <note priority="1" from="description">Title of a section of the form</note>
+        <note priority="1" from="meaning">Organization profile</note>
+      </trans-unit>
+      <trans-unit id="6a6369d9cf34dd7374275a93fea20c243877bf99" datatype="html">
+        <source>Less details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">291</context>
+        </context-group>
+        <note priority="1" from="description">Less details button</note>
+      </trans-unit>
+      <trans-unit id="711a50f8cce91ebfb36614abe4e25c400480c269" datatype="html">
+        <source>More details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">292</context>
+        </context-group>
+        <note priority="1" from="description">More details button</note>
+      </trans-unit>
+      <trans-unit id="b4b9d2e75328589d6f50655d26d370b8a8168365" datatype="html">
+        <source>Discard changes</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">303</context>
+        </context-group>
+        <note priority="1" from="description">Discard change button</note>
+      </trans-unit>
+      <trans-unit id="5b3075e8dc3f3921ec316b0bd83b6d14a06c1a4f" datatype="html">
+        <source>Save changes</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
+          <context context-type="linenumber">304</context>
+        </context-group>
+        <note priority="1" from="description">Save changes button</note>
+      </trans-unit>
+      <trans-unit id="dafa8a6b3ce5af28ce08ad9b57a82328126b5003" datatype="html">
+        <source>Update observation</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Observation edition</note>
+      </trans-unit>
+      <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
+        <source>Cancel</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">141</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">147</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">85</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">135</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">141</context>
+        </context-group>
+        <note priority="1" from="description">Cancel button</note>
+      </trans-unit>
+      <trans-unit id="047f50bc5b5d17b5bec0196355953e1a5c590ddb" datatype="html">
+        <source>Update</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">142</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">148</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">80</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">88</context>
+        </context-group>
+        <note priority="1" from="description">Update button</note>
+      </trans-unit>
+      <trans-unit id="2ced27c89ab044b68b5fc5f112e9fdb823d78073" datatype="html">
+        <source>Type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Label for the type field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
+        <source>Operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <note priority="1" from="description">Observation type</note>
+      </trans-unit>
+      <trans-unit id="edd600fa489d1b4a4448dce694ed932e52ce8fda" datatype="html">
+        <source>Governance</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Observation type</note>
+      </trans-unit>
+      <trans-unit id="8ac4ffef0bab3e3fef5a739f8f0659a27edbf5ab" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="66c8bc89c06a678f7956435165f15539fb6fcbf9" datatype="html">
+        <source>Please select a country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f81df4984ec9a7a25ca1a255e70c37cf0b3fc768" datatype="html">
+        <source>Latitude</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <note priority="1" from="description">Label for the latitude field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="9103deeab9ec8e9c404a9b613f32c40f8b81435b" datatype="html">
+        <source>Latitude is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the latitude isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="4d643d02cb8a26d011ecbc2cc65e36d6c79285b6" datatype="html">
+        <source>Please enter a valid number</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the latitude isn&apos;t valid</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="bcb1edd093495a7f451ec73bda71a390fd9b7bb0" datatype="html">
+        <source>Longitude</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <note priority="1" from="description">Label for the longitude field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="dfe47cc2c10ef51aec72676718979323da406949" datatype="html">
+        <source>Longitude is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the longitude isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="47147103a9753d3a57d16858149ad097aef3a20c" datatype="html">
+        <source>Sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+        <note priority="1" from="description">Label for the sub-category field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6bedd241a7533daaee02997b78ec87bdd2d2fb5a" datatype="html">
+        <source>Please select a sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">60</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the sub-category isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2836d984c7fd9f88dde6ca18f69d18ae66c268e2" datatype="html">
+        <source>Severity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <note priority="1" from="description">Label for the severity field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="4f9d0961548c19b80893a1354e2ffd8dad7347f4" datatype="html">
+        <source>Please select a severity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the severity isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1497e5043b0c1da86c5469b69d4c7497ff523438" datatype="html">
+        <source>Publication date</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <note priority="1" from="description">Label for the publication date field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="849521cde58edf20f3e8b3d596c0b4843603b3e8" datatype="html">
+        <source>Publication date is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the publication date isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="59cfebb84dc089e652e54b56dfd1127f5331bd8c" datatype="html">
+        <source>Government Entity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+        <note priority="1" from="description">Label for the government entity field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f0fd741b7784b50be4e7de22cc464106848b6673" datatype="html">
+        <source>Please select a government entity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the government entity isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="755a1c920f1be9572a38de2d2b0dda3b701c78f4" datatype="html">
+        <source>PV</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+        <note priority="1" from="description">Label for the PV field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="7ced18ad4df34b20929de05b0ebe6bfa213c5472" datatype="html">
+        <source>Opinion of operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+        <note priority="1" from="description">Label for the opinion of operator field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f066e1eb28d8ae8a8877b138277b4c05e1c0c226" datatype="html">
+        <source>Litigation status</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+        <note priority="1" from="description">Label for the litigation status field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="b4a2de6607352730a6af5fcb59263e27439f2c5a" datatype="html">
+        <source>Monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">107</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <note priority="1" from="description">Label for the monitor field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="ffeb07b7af4b3905ed99ac72ad636ca63bc05dc8" datatype="html">
+        <source>Please select a monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">105</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the monitor isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="dd2f34de17cff8207d4e0ec104bc093faac2b8eb" datatype="html">
+        <source>Operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">115</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <note priority="1" from="description">Label for the operator field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c70b9e0c5e8e83b7427e178e4f95ab6559c43224" datatype="html">
+        <source>Please select an operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">113</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the operator isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="711d402d0117e5b0abb02c988648b9c41ea13975" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">123</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">117</context>
+        </context-group>
+        <note priority="1" from="description">Label for the active field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c324d1ec6ff085cd19e6bce739b05ad9475e0672" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">122</context>
+        </context-group>
+        <note priority="1" from="description">Label for the details field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="7e9e4e7c021c606a03a4cd3f5b9331bd37fb109d" datatype="html">
+        <source>Evidence</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
+          <context context-type="linenumber">133</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
+        <note priority="1" from="description">Label for the evidence field</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="536f971e3d6c6ed722df6f46081168ddd2d2aa5d" datatype="html">
+        <source>
+      New governance sub-category
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a governance sub-category</note>
+      </trans-unit>
+      <trans-unit id="f59e607fb08307278ff4d632a8403cc7250f40b7" datatype="html">
+        <source>Governance Pillar</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the governance pillar of the governance sub-categories</note>
+        <note priority="1" from="meaning">Table of governance sub-categories</note>
+      </trans-unit>
+      <trans-unit id="646cbe17a5d08e57cb34928dfe7fa7cd23481ce0" datatype="html">
+        <source>Governance Problem</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the governance problem of the governance sub-categories</note>
+        <note priority="1" from="meaning">Table of governance sub-categories</note>
+      </trans-unit>
+      <trans-unit id="f5f4971be2896724f7402e018c02e4998d0f7165" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of governance sub-categories</note>
+      </trans-unit>
+      <trans-unit id="7d29efb5dea57b061811390c578b3c386ac28802" datatype="html">
+        <source>Sub-categories (Governance)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the governance sub-categories</note>
+      </trans-unit>
+      <trans-unit id="9c16ee275da84e3a95d9ee5f7bb01a42ef3df5b2" datatype="html">
+        <source>New governance sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Governance sub-category creation</note>
+      </trans-unit>
+      <trans-unit id="7891175220c7fe8e6e94d10cf7726ede071792fc" datatype="html">
+        <source>Update governance sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Governance sub-category edition</note>
+      </trans-unit>
+      <trans-unit id="70a67e04629f6d412db0a12d51820b480788d795" datatype="html">
+        <source>Create</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">77</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">87</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">136</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">142</context>
+        </context-group>
+        <note priority="1" from="description">Create button</note>
+      </trans-unit>
+      <trans-unit id="6909f80c54d37a94153b18d639d4dbf990634bf7" datatype="html">
+        <source>Governance pillar</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the governance pillar field</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6ed681ff2468c607172396fc02a073dac8b4efaf" datatype="html">
+        <source>Governance pillar is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the governance pillar isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="a7dc4236b38404ed8d4aa4c9fb780ccc040ccd9e" datatype="html">
+        <source>Governance problem</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <note priority="1" from="description">Label for the governance problem field</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="54b7e1b3b75e6445b2f2e6784cb3be46286ea10d" datatype="html">
+        <source>Governance problem is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the governance problem isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c277d5768b2a4c5b1925b6c0dc7ec58ae1bc1d05" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Label for the details field</note>
+        <note priority="1" from="meaning">Governance sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="609e416695033263472042503c888c0461e7bf99" datatype="html">
+        <source>
+      New operator sub-category
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a operator sub-category</note>
+      </trans-unit>
+      <trans-unit id="400ca8ca7107a0d8e8929b04d8fc4c185d183f1b" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the operator sub-categories</note>
+        <note priority="1" from="meaning">Table of operator sub-categories</note>
+      </trans-unit>
+      <trans-unit id="31f4b66a2ffe7471f4f39930204bc4f382f5dfd3" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the detail of the operator sub-categories</note>
+        <note priority="1" from="meaning">Table of operator sub-categories</note>
+      </trans-unit>
+      <trans-unit id="f63250c4baab4b9281bc0babcc6ff86338771d19" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of operator sub-categories</note>
+      </trans-unit>
+      <trans-unit id="01913c9d313d04a592d6aa364ad1e8b13717cd42" datatype="html">
+        <source>Sub-categories (Operators)</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the operator sub-categories</note>
+      </trans-unit>
+      <trans-unit id="1da555b26e38aea784e23a1092afa8ba60693dbb" datatype="html">
+        <source>New operator sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Operator sub-category creation</note>
+      </trans-unit>
+      <trans-unit id="773e146f4baed993f7e61607302504f702ebef35" datatype="html">
+        <source>Update operator sub-category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Operator sub-category edition</note>
+      </trans-unit>
+      <trans-unit id="8e29884856ab62e66baed2206fe9f251c542932e" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="cf8f4120bf44e9a770d8d4ec2cf0f68c2db7f24e" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="e5ed666f8f6a2589cd3c7979b243e5bc6f78d60d" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1ca5483adf9af728d5d0a98cd364a694cc422e63" datatype="html">
+        <source>Law references</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Label for the law references field</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="0a6091f7c64135d8ec9439019908e8f1e6d28d6b" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <note priority="1" from="description">Label for the details field</note>
+        <note priority="1" from="meaning">Operator sub-category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="85afe36487fab2e70904c3d796f0ea2f7a5a90a9" datatype="html">
+        <source>New category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Category creation</note>
+      </trans-unit>
+      <trans-unit id="c9315cc027fda44df7772e7fa05aa74402dc017d" datatype="html">
+        <source>Update category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Category edition</note>
+      </trans-unit>
+      <trans-unit id="48df2497540119700a2d0e0f26d629c837fd7fc6" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2637b135fb7dc9dab5d9b2cd507716b80cb98240" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Category creation/edition</note>
+      </trans-unit>
+      <trans-unit id="d3392cb23bca77d1014e89b5e8aefcfb4ccad87b" datatype="html">
+        <source>
+      New Operator
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new operator</note>
+      </trans-unit>
+      <trans-unit id="801e19d7c8bfcbcc9ede4749d1885f45759b8c8b" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the operators</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="60a3c060cf7bbe40ffbfc35b0b3bb691a789a4e7" datatype="html">
+        <source>Type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the type of the operators</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="4f00329eba86dfea8ce882af55cbe475c00c1036" datatype="html">
+        <source>Concession</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the concession of the operators</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="b029eee35172b814101cf828fb5f9a61e1391c0f" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the whether or not the operators are active</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="39ffe1e95aa519b9645e62af04ed0a3cfa032b42" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of operators</note>
+      </trans-unit>
+      <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
+        <source>Operators</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the operators</note>
+      </trans-unit>
+      <trans-unit id="1dbd4bf0057e786321c83ca35a3c4e2b77f181a9" datatype="html">
+        <source>New operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Operator creation</note>
+      </trans-unit>
+      <trans-unit id="f0a8d16cabce095b3508ff9dbeb0459b33249e5d" datatype="html">
+        <source>Update operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Operator creation</note>
+      </trans-unit>
+      <trans-unit id="9fd38b8fcd5e17ff3611d046ce724e16a2000109" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="77728cbe1d84a03b45077d0bcdb10f2ccbeb223e" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f152c650bc08e63a3b7a2471c3ef3ab62cf3d52b" datatype="html">
+        <source>Operator type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the operator type field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2a0e9f550a391aa5b4639d2c85ba060358390726" datatype="html">
+        <source>Logging</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="6ef0619a37140118b9e640c6cc36ee4e9fb4372a" datatype="html">
+        <source>Company</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="99186438c83c4c7e8b9cc78dfa43f7fd524b5e6e" datatype="html">
+        <source>Artisanal</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="0ad4531bb4bd5e0c7770dfdd89a99befcad6c8ea" datatype="html">
+        <source>Sawmill</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="f5a5b7fe27eecc145ce874a267d55abd47590494" datatype="html">
+        <source>Community Forest</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="e856ab987b69555ee8e5f8cd7e442de3eabea7f4" datatype="html">
+        <source>ARB1327</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="33cf379d245d5fb087711431420fb0ef6ed3e43b" datatype="html">
+        <source>Palm Oil</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="5d79e032a7657d92b56373c5cc20d0724ef9c73a" datatype="html">
+        <source>Trader</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <note priority="1" from="description">Operator type</note>
+      </trans-unit>
+      <trans-unit id="cafbab33e33e79a58b4eefad43938b99d0426314" datatype="html">
+        <source>Please select an operator type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the operator type isn&apos;t supplied (the user will have to choose between several options)</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="fe69558920c9d7980d3f3acf5c1ac18191b180d9" datatype="html">
+        <source>
+      <x id="START_TAG_LABEL" ctype="x-label"/>Country<x id="CLOSE_TAG_LABEL" ctype="x-label"/>
+      <x id="START_TAG_SELECT" ctype="x-select"/>
+        <x id="START_TAG_OPTION" ctype="x-option"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_OPTION" ctype="x-option"/>
+      <x id="CLOSE_TAG_SELECT" ctype="x-select"/>
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="8c88e1c3c79928abc132f9da3d38a81a8511fa0a" datatype="html">
+        <source>Concession</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <note priority="1" from="description">Label for the concession field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="3934c8285a2371995bd611a986efcbfa9253b8e2" datatype="html">
+        <source>Country centroid</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country centroid field</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1e033c6c092d12800660484eec7a772925639eb6" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+        <note priority="1" from="description">Label for the field to tell whether the operator is active or not</note>
+        <note priority="1" from="meaning">Operator creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2f4c185a5507bc6ff049778effdc2ca682aab774" datatype="html">
+        <source>
+      New Country
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new country</note>
+      </trans-unit>
+      <trans-unit id="de0beb4f2c7b3619f47224ad8a5feedb860dfc0c" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the countries</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="b9d28a4b3787fdb725362102e55e54541497723c" datatype="html">
+        <source>ISO</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the ISO code of the countries</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="902f1ade07cad3f447858b17c2da63e8f7e26ce8" datatype="html">
+        <source>Region Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the region name of the countries</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="6bb7c94296bdb62165caa3ed3e9151390c0811f9" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to whether or not the countries are active</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="ab07255a444e77bef3e19ddaca4b72a1c8eb360e" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of countries</note>
+      </trans-unit>
+      <trans-unit id="aee7d0de4e30405c1289745e4264e622b613632a" datatype="html">
+        <source>Countries</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the countries</note>
+      </trans-unit>
+      <trans-unit id="e4a0e02a470737d8053a8ced70e98d1978442484" datatype="html">
+        <source>New country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Country creation</note>
+      </trans-unit>
+      <trans-unit id="c9eed87bc1809a6190cb533f6e034c8c240721ea" datatype="html">
+        <source>Update country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Country edition</note>
+      </trans-unit>
+      <trans-unit id="f9a075ede38c8f0b8e1ebc8a636ff9c2e1d2d5ac" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="7772f40a6bf4492246a964933bcd562d63690558" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="fa04f51e70170a51b8409850619f58194170bf81" datatype="html">
+        <source>Region name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the region name field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="5620a84efc9854a3c1c04b51762b8c12ff7ba334" datatype="html">
+        <source>ISO</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Label for the ISO code field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="85c0d8144b112baf450f3265187ed54f3cedb65a" datatype="html">
+        <source>ISO is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the ISO code isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2808eef1afd0850f3fc4d5bb4af9c8d760a83537" datatype="html">
+        <source>Region ISO</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">Label for the region ISO code field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f4ba7b2b4ecc25e0b57747d4cc613996662cb0c4" datatype="html">
+        <source>Country centroid</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country centroid field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6dc87818baaf0762c2e63182ecbf55ef11907b2a" datatype="html">
+        <source>Region centroid</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <note priority="1" from="description">Label for the region centroid field</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="8a1e8e453f1ca7b66f462780f073fd214fd7a012" datatype="html">
+        <source>Available for observations?</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <note priority="1" from="description">Label for the field that let the user select if the country will be available for observations</note>
+        <note priority="1" from="meaning">Country creation/edition</note>
+      </trans-unit>
+      <trans-unit id="ca902a857f64589071e0712f19210e799ee0fba4" datatype="html">
+        <source>
+      New species
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new species</note>
+      </trans-unit>
+      <trans-unit id="7d1762ee4d496a6c991fde6dcfbec7af4144c1cc" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the species</note>
+        <note priority="1" from="meaning">Table of species</note>
+      </trans-unit>
+      <trans-unit id="79c4cd49d2cd2f84007b9e115400686f56986a1e" datatype="html">
+        <source>Species class</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the species class of the species</note>
+        <note priority="1" from="meaning">Table of species</note>
+      </trans-unit>
+      <trans-unit id="c7703ff5d60e6ef26ff13b44cbb0265e145a1888" datatype="html">
+        <source>Scientific name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the scientific name of the species</note>
+        <note priority="1" from="meaning">Table of species</note>
+      </trans-unit>
+      <trans-unit id="6a5cd6a6798a329a413178bdbbbe22c5edd66d89" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of species</note>
+      </trans-unit>
+      <trans-unit id="ec2b122ed8617f51ed128267a65711e40e56b5bc" datatype="html">
+        <source>Species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the species</note>
+      </trans-unit>
+      <trans-unit id="eb53d60e9bf9ae875707a6941231e2a21c7f1120" datatype="html">
+        <source>
+      New Monitor
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new monitor</note>
+      </trans-unit>
+      <trans-unit id="ebe3ca55e2a451ca15ee5d9b7310f0377b6e2b0e" datatype="html">
+        <source>Date</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the date of the monitors</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="c818c652325d319c5fa88875471f20eb663a12b3" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the monitors</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="b2ef1717958c380c23c8921591715b7fbaf91cb8" datatype="html">
+        <source>Type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the type of monitors</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="b1d9f070c335abb9c7877c5effde44fc31d7346c" datatype="html">
+        <source>Organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the organizations of the monitors</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="b4237c13c658454f4a55897e4a3cf73c30a80e0e" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the whether the monitors are active or not</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="53e3ce2b1d00ae0c8f1f2d8cabbab9cfd91c67ff" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of monitors</note>
+      </trans-unit>
+      <trans-unit id="258847bc2f56543f10b58ce2f85c72994567bcb6" datatype="html">
+        <source>
+      New law
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new law</note>
+      </trans-unit>
+      <trans-unit id="67572ae9cc69d32f40b3259490b91cecc3f5f85d" datatype="html">
+        <source>Legal Reference</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the legal reference of the laws</note>
+        <note priority="1" from="meaning">Table of laws</note>
+      </trans-unit>
+      <trans-unit id="94380867a6d2b9b39396e6754e7d10d8ebe9085e" datatype="html">
+        <source>Legal Penalty</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the legal penalty of the laws</note>
+        <note priority="1" from="meaning">Table of laws</note>
+      </trans-unit>
+      <trans-unit id="8070d4dfa7c8357d6d5ce2b1f920d6d584dc9cdc" datatype="html">
+        <source>VPA indicator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the VPA indicator of the laws</note>
+        <note priority="1" from="meaning">Table of laws</note>
+      </trans-unit>
+      <trans-unit id="0610fd99f9f9b25f432fb2bd65249748420efc70" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of laws</note>
+      </trans-unit>
+      <trans-unit id="d9f85cde7086ccd4c97fc1ae6e656dd68db51d4b" datatype="html">
+        <source>Laws</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the laws</note>
+      </trans-unit>
+      <trans-unit id="ebc02487572b7b91efac0f364a963de1836fc422" datatype="html">
+        <source>New species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Species creation</note>
+      </trans-unit>
+      <trans-unit id="4e20ed317e78bb9276d249261909b0dd7b89fdbe" datatype="html">
+        <source>Update species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Species edition</note>
+      </trans-unit>
+      <trans-unit id="9450101fd324b122e3c2eebe39ea1efb73ed835a" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6e79c544a6f881f3b2bc6c311136b1b07e61db80" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6513c8fc3343f39e6523ebcb32977f7fd74a6042" datatype="html">
+        <source>Common name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Label for the common name field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="dd0a5f500aef0ecaac829d038616a1c561b644e7" datatype="html">
+        <source>Scientific name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Label for the scientific name field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2cbd3b29e44968bc1915613d5cd3e31b41237adb" datatype="html">
+        <source>Species class</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">Label for the species class field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="53f592247ce5bd687d87c9e07f6d9eed9d30da20" datatype="html">
+        <source>Sub species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <note priority="1" from="description">Label for the sub species field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="20b6a2bdb411d5ee55c944816a0632c5f4ce8917" datatype="html">
+        <source>Species family</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <note priority="1" from="description">Label for the species family field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f2203853494dd5e56d65f8ec663b0a9c5d627b55" datatype="html">
+        <source>Kingdom</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <note priority="1" from="description">Label for the kingdom field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="d1cd8111b4fe023923f890c0a7c44cc94cada286" datatype="html">
+        <source>CITES status</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <note priority="1" from="description">Label for the CITES status field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1f823441a94afdbe8a76e2677645c4dee6bdb3b3" datatype="html">
+        <source>IUCN status</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <note priority="1" from="description">Label for the IUCN status field</note>
+        <note priority="1" from="meaning">Species creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f7b77c07f0f64b0f4946d066ccb7caf42f6d64f5" datatype="html">
+        <source>New monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Monitor creation</note>
+      </trans-unit>
+      <trans-unit id="d37e644a3c2fe4a97af5fc04c5ba23c50ca0d1bc" datatype="html">
+        <source>Update monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Monitor edition</note>
+      </trans-unit>
+      <trans-unit id="970d6446f3e343408a02266007c4782e5ffc18e2" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2f23d7732da6de204b25e720af0932539533f290" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f09fef617d6a9de0ef89d7e9a9582ebe111dd27e" datatype="html">
+        <source>Monitor type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Label for the monitor type field</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="72638e600ce222ed8184c47260bbd68d362e693e" datatype="html">
+        <source>External</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Type of monitor</note>
+      </trans-unit>
+      <trans-unit id="59d614de306c59782f5daa000ac64ab78986dfe3" datatype="html">
+        <source>Government</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Type of monitor</note>
+      </trans-unit>
+      <trans-unit id="f92e4776a0e55bc1f62e42a33492a06fcf1ef6f4" datatype="html">
+        <source>Please select a type of monitor</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the monitor type isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="56e1213f23dc45ca22b840ca175d09878c2fa327" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="c474aac05e8433059be3ef9df630c75d919d91f0" datatype="html">
+        <source>Organization</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <note priority="1" from="description">Label for the organization&apos;s name field</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="2423329875b86c153e867d7b73ca084967a5ca4d" datatype="html">
+        <source>Active</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <note priority="1" from="description">Label for the field to tell whether the monitor is active or not</note>
+        <note priority="1" from="meaning">Monitor creation/edition</note>
+      </trans-unit>
+      <trans-unit id="902d8c9a37cd5dbfbf804818d51018f57ee5ff6f" datatype="html">
+        <source>New law</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Law creation</note>
+      </trans-unit>
+      <trans-unit id="f936a2051fc16836b5957df80ea4daf45dac6fb4" datatype="html">
+        <source>Update law</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Law edition</note>
+      </trans-unit>
+      <trans-unit id="4ed0d6f64ddd3927b180003fed3cfec68eeca9fc" datatype="html">
+        <source>Legal reference</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the legal reference field</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1f5821b1de3e5287dd47d5afd1c73e8481f334a4" datatype="html">
+        <source>Legal reference is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the legal reference isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="5dee6b0be929a8b581a7d1e1dadb99163583707d" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="5909daed5b4040739fd19794fc9eb601db3840f7" datatype="html">
+        <source>Please select a country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="0ba722b8181589f48f6982c2e6289a3a7e638b30" datatype="html">
+        <source>VPA indicator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Label for the VPA indicator field</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="da81d170cec9c56d085e1a83d72a75083fb34bde" datatype="html">
+        <source>Legal penalty</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">Label for the legal penalty field</note>
+        <note priority="1" from="meaning">Law creation/edition</note>
+      </trans-unit>
+      <trans-unit id="da0e191e3b5ce9a03ebf6935c7a3da8f1df39963" datatype="html">
+        <source>New government</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Government creation</note>
+      </trans-unit>
+      <trans-unit id="d63b452dfa4a1be6a31c188edf56b946a9bc3a36" datatype="html">
+        <source>Update government</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Government creation</note>
+      </trans-unit>
+      <trans-unit id="994f851a27e09e9b2eb725f832cc0d6406362b63" datatype="html">
+        <source>Government entity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the government entity field</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="d3a14f1a9f2eccb2b150c1a53d36ff3642f41664" datatype="html">
+        <source>Government entity is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the government entity isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="0b577ea470cf9239b9ee5a7f49e1648b38450413" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="f2fae309178d62c60d650f78ee2f5076fc48cb02" datatype="html">
+        <source>Please select a country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to choose between serveral options)</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="070870f728185c5169acfbd58382939274fcbc27" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Label for the details field</note>
+        <note priority="1" from="meaning">Government creation/edition</note>
+      </trans-unit>
+      <trans-unit id="263deacc741fd6429b2a1fd3719ded604f0799d0" datatype="html">
+        <source>
+      New government unit
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new government unit</note>
+      </trans-unit>
+      <trans-unit id="7375730a696290da1ac4a1b41aa1807227704d38" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the governments</note>
+        <note priority="1" from="meaning">Table of governments</note>
+      </trans-unit>
+      <trans-unit id="a77615221336090843bf4217630174cf0aaadcb2" datatype="html">
+        <source>Details</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the details of the governments</note>
+        <note priority="1" from="meaning">Table of governments</note>
+      </trans-unit>
+      <trans-unit id="77d0d5ee531ac0867be1b0ce429d9f23314fa4cd" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of governments</note>
+      </trans-unit>
+      <trans-unit id="648fe89999cc59abebc2ff5e62c7f4f619bf456e" datatype="html">
+        <source>Governments</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the governments</note>
+      </trans-unit>
+      <trans-unit id="bf0b87b1211a6459b83e5f3774a659e5d2e77b9f" datatype="html">
+        <source>
+      New Category
+    </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new category</note>
+      </trans-unit>
+      <trans-unit id="3e44dbcc81d17832a393250e494929e0b6382c0b" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the categories</note>
+        <note priority="1" from="meaning">Table of categories</note>
+      </trans-unit>
+      <trans-unit id="a0d9d59763903ebae40d4d8e3b62ffbf5d3d717a" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of categories</note>
+      </trans-unit>
+      <trans-unit id="04201f9d27abd7d6f58a4328ab98063ce1072006" datatype="html">
+        <source>Categories</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the categories</note>
+      </trans-unit>
+      <trans-unit id="daf4f4c015509bb67eb6d6d726b256a8615d7758" datatype="html">
+        <source>Open Timber Portal</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Name of the app</note>
+      </trans-unit>
+      <trans-unit id="3fdc751b264ca9998e1542fcf5794e274cd56344" datatype="html">
+        <source>Log out</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Log out button</note>
+      </trans-unit>
+      <trans-unit id="1ae1df848c628a7a059c1ff57be3449ecacc5c91" datatype="html">
+        <source>New user</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">User creation</note>
+      </trans-unit>
+      <trans-unit id="7663160100ebcc9a117c8cb206b0624e172f89c9" datatype="html">
+        <source>Update user</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">User edition</note>
+      </trans-unit>
+      <trans-unit id="4b43d07d0171b690cd5d541d649389af16378912" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field (name of the person)</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="a8077802820f0bac578cee128f3146719d87c292" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="9531f868dd03aac6f0d2687eed93dd57d4fcb910" datatype="html">
+        <source>Username</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Label for the username field (a nickname)</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="517d85ca7650f90dd91f14a4e3ecffab28967926" datatype="html">
+        <source>Username is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the username/nickname isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="62dc5076c0fe3427ba6a0ed17008cecea393c1a1" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">Label for the email field</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="6c46fe594e7a68965a97b78ef5e22859e5781d68" datatype="html">
+        <source>Email is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="ad967d9088a765aebf92c3116b8f5398d6e2de09" datatype="html">
+        <source>Please enter an email address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="9515b8c96b948fff69c74667be3248115e876ed2" datatype="html">
+        <source>Institution</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <note priority="1" from="description">Label for the institution field (name of the insitution, organization)</note>
+        <note priority="1" from="meaning">User creation</note>
+      </trans-unit>
+      <trans-unit id="e9959215c7e71edde620b01439f5ffbecd5d2b27" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="4fe21c99a9c7a18ae378c3e0958b146f21e56ad9" datatype="html">
+        <source>Password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password field</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="795dfb8a206622b513661b3ecdb0e697e4cd1e0f" datatype="html">
+        <source>Password is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="0decdfdf829ae2fdedebac57ce24f1cbdca085fb" datatype="html">
+        <source>Confirm your password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password confirmation field</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="8c0add49e7d050ab76f5f1bf53b43410f95d73bb" datatype="html">
+        <source>Please confirm your password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password confirmation isn&apos;t supplied</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="03a6fc721e7fcdae64bb5982a0674ca3c45d1870" datatype="html">
+        <source>Password values don&apos;t not coincide</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password and its confirmation don&apos;t coincide&apos;</note>
+        <note priority="1" from="meaning">User creation/edition</note>
+      </trans-unit>
+      <trans-unit id="d0003e833df402846f87694894de69a744609fcb" datatype="html">
+        <source>Permissions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <note priority="1" from="description">Label for the permissions field (the user will have to choose a role)</note>
+        <note priority="1" from="meaning">User creation</note>
+      </trans-unit>
+      <trans-unit id="408cb6073e60c5d966296a3207fc596adca75e01" datatype="html">
+        <source>Admin</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <note priority="1" from="description">User role</note>
+      </trans-unit>
+      <trans-unit id="e652540fcb10505228ef38a3a9790a94a3728fc5" datatype="html">
+        <source>NGO</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <note priority="1" from="description">User role</note>
+      </trans-unit>
+      <trans-unit id="f3dba5732cb548f04fc8b4727e3568f5169956f1" datatype="html">
+        <source>New observation</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Observation creation</note>
+      </trans-unit>
+      <trans-unit id="a01fcf88689d79ed060dce1f72b5adeaa7b46faf" datatype="html">
+        <source>Please select a observation type</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the type isn&apos;t supplied (the user will have to user between some options)</note>
+        <note priority="1" from="meaning">Observation creation/edition</note>
+      </trans-unit>
+      <trans-unit id="1a6f616703d75ae22ef5f11706c3815ca04888c5" datatype="html">
+        <source>
+        New user
+      </source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new user</note>
+      </trans-unit>
+      <trans-unit id="408d18faf367209fe427e59b979f2b44901e0e7c" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the name of the users</note>
+        <note priority="1" from="meaning">Table of users</note>
+      </trans-unit>
+      <trans-unit id="0a15a5d859d810d87d241e8c1e0320a6bf4eaab6" datatype="html">
+        <source>Username</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the username/nickname of the users</note>
+        <note priority="1" from="meaning">Table of users</note>
+      </trans-unit>
+      <trans-unit id="d9a3cb1133a129319296a62a6592ccb4633c37ad" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the email of the users</note>
+        <note priority="1" from="meaning">Table of users</note>
+      </trans-unit>
+      <trans-unit id="7ed96443291c57e0eef0a6f1adcbf1a3013449a4" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of users</note>
+      </trans-unit>
+      <trans-unit id="4d13a9cd5ed3dcee0eab22cb25198d43886942be" datatype="html">
+        <source>Users</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the users</note>
+      </trans-unit>
+      <trans-unit id="30e10cd5f105624805db7f96287a3b7edd5fff9c" datatype="html">
+        <source>My OTP</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <note priority="1" from="description">My OTP menu option</note>
+      </trans-unit>
+      <trans-unit id="4b8c7b2a240e413c2c1eb4a69abf371ac5c5742e" datatype="html">
+        <source>Observations</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Observations menu option</note>
+      </trans-unit>
+      <trans-unit id="faf74edc4404313eeb85945cc1a99cc4ff4a6fd6" datatype="html">
+        <source>Fields</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Fields menu option</note>
+      </trans-unit>
+      <trans-unit id="099668cc93fe681254739694dc7d662069a8b659" datatype="html">
+        <source>Register</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="245198374604dd2866e843ca1411b3b5bee26b4b" datatype="html">
+        <source>Name</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Label for the name field (name of the person)</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="455490d6079d0287a4dd8a51d0087c7df48e018c" datatype="html">
+        <source>Name is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="077471e569722451975586da916fe91f1eede0f0" datatype="html">
+        <source>Username</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Label for the username field (a nickname)</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="89434c6c32783ce50a9818d919b0cfcf1883dfe7" datatype="html">
+        <source>Username is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the username/nickname isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="67e26ffa056d34f8f5c34cfe01af731f4667d420" datatype="html">
+        <source>Institution</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Label for the institution field (name of the insitution, organization)</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="ff8c80b065ad5802b5d2539e41ec7bfa14c65646" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Label for the country field (the user will have to choose between some options)</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="0e420cff0712db35b0fb636b9c7b73182307ee48" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Label for the email field</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="e3e6b8f98dd44b6c1cb5834713b771004b15369a" datatype="html">
+        <source>Email is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="0852bccb9acdfc7c24ea9f89f997812e20c5f66c" datatype="html">
+        <source>Please enter an email address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="8878633ec07d9bfe29eaf51cf501e87fe3df588f" datatype="html">
+        <source>Password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password field</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="37259b13dc58cf4ece14d58b0e3c3dc883105168" datatype="html">
+        <source>Password is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="87d9a4f470c63e0b8bfe7279223532e87adf6f08" datatype="html">
+        <source>Confirm your password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password confirmation field</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="a6f6372f4dd465f68c31293774b454b477bdc918" datatype="html">
+        <source>Please confirm your password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password confirmation isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="c45bce7d5bebd3886fa2ec661b234da55c062f54" datatype="html">
+        <source>Password values don&apos;t not coincide</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password and it&apos;s confirmation don&apos;t coincide</note>
+        <note priority="1" from="meaning">Register page</note>
+      </trans-unit>
+      <trans-unit id="6765b4c916060f6bc42d9bb69e80377dbcb5e4e9" datatype="html">
+        <source>Login</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Button to log in</note>
+      </trans-unit>
+      <trans-unit id="cfc2f436ec2beffb042e7511a73c89c372e86a6c" datatype="html">
+        <source>Register</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/register/register.component.ts</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Button to register</note>
+      </trans-unit>
+      <trans-unit id="229210ea5aded39aacf9e7d79e1658b32ca104f6" datatype="html">
+        <source>New observation</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Button to create a new observation</note>
+      </trans-unit>
+      <trans-unit id="00c200adab3e41e35d1e06d42d847d17f747e71c" datatype="html">
+        <source>Date</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the date of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="645872c938ac5195a4906afa0f6118cc9b52771b" datatype="html">
+        <source>Country</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the country of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="0ea6d0e3424fa1ffdb64a3b98a9815c98b595435" datatype="html">
+        <source>Operator</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the operator name of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="be0139f1cf8e5feab4a5b691287c7c0d9c74fc86" datatype="html">
+        <source>Category</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the category of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="788391ad82018522ef4162b47fb8e81f00217bd6" datatype="html">
+        <source>Observation</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the details of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="a8a36702a876525737fdbabb99b6f5bceac167a6" datatype="html">
+        <source>Severity</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <note priority="1" from="description">Name of the column corresponding to the severity of the observations</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="f988c370ec8c750c0b84a0c412e440d53cee631d" datatype="html">
+        <source>Actions</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
+        <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="8d68caf60e263e599e86d21321e1939323492821" datatype="html">
+        <source>Login</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Title of the page</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="4d8a562e319cebae08fb094877d11d80be7ed87d" datatype="html">
+        <source>Email</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Label for the email field</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="4c7f617fdaf91a9d45c52aa985e99304538bf140" datatype="html">
+        <source>Email is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="dec04191c54f62c23d2012fafcb24c07c198ba58" datatype="html">
+        <source>Please enter an email address</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="69a2b7b2e465e58e7df02173034ee5f9c332ad70" datatype="html">
+        <source>Password</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Label for the password field</note>
+        <note priority="1" from="meaning">Login page</note>
+      </trans-unit>
+      <trans-unit id="ee6940c10dba8bb8734ddb805ccc75c02f0ace8b" datatype="html">
+        <source>Password is required</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/login/login.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
+        <note priority="1" from="meaning">Login page</note>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -80,6 +80,34 @@
         <note priority="1" from="description">Next page button</note>
         <note priority="1" from="meaning">Table paginator</note>
       </trans-unit>
+      <trans-unit id="65701e62f4eb6566c62a6088842f6f95fa8ef48e" datatype="html">
+        <source>Organization profile</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;My OTP&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="fb32420414820f45d127a9e6f51985800d930fbb" datatype="html">
+        <source>My observations</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;My OTP&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
       <trans-unit id="fa9b7116761f013fe509c7646dee9d1e9c3cc31a" datatype="html">
         <source>Name of the organization</source>
         <target/>
@@ -1692,6 +1720,42 @@
         <note priority="1" from="description">Label for the details field</note>
         <note priority="1" from="meaning">Operator sub-category creation/edition</note>
       </trans-unit>
+      <trans-unit id="ad9508c67f58f44fd3b4d73925e50fa53de76fb7" datatype="html">
+        <source>Operators</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/subcategories.component.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Sub-categories&apos; list page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="cefad27e0f05695d2e7d84403f5370fa0ac85c5f" datatype="html">
+        <source>Governance</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/subcategories/subcategories.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Sub-categories&apos; list page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
       <trans-unit id="85afe36487fab2e70904c3d796f0ea2f7a5a90a9" datatype="html">
         <source>New category</source>
         <target/>
@@ -2844,6 +2908,58 @@
         </context-group>
         <note priority="1" from="description">Log out button</note>
       </trans-unit>
+      <trans-unit id="791b002647a2f49818c508b2860c68e7f23b17b6" datatype="html">
+        <source>My OTP</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <note priority="1" from="description">Main navigation menu (desktop)</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="831b9ec431d2a93a412ef510bd1fae36c721400a" datatype="html">
+        <source>Observations</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+        <note priority="1" from="description">Main navigation menu (desktop)</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="dbe0f319ddd1cc5c17d1a4e9585996c89fd2d05c" datatype="html">
+        <source>Observation fields</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Main navigation menu (desktop)</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="74b0fac259eeefc9f20aeb6a1bd08931012390c9" datatype="html">
+        <source>Users</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/header/header.component.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Main navigation menu (desktop)</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
       <trans-unit id="1ae1df848c628a7a059c1ff57be3449ecacc5c91" datatype="html">
         <source>New user</source>
         <target/>
@@ -3052,6 +3168,104 @@
         <note priority="1" from="description">Error message if the type isn&apos;t supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
+      <trans-unit id="5c50b2cbccccfacca324cac86084eea6dca8a9b6" datatype="html">
+        <source>Categories</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="c5c1ede612299da54bd1911c2afff91164c6d67d" datatype="html">
+        <source>Sub-categories</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="c61f95bc9d62cf3b27e0de4d2ccafdec84025876" datatype="html">
+        <source>Species</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="cbaa4c8a4a07ae77d139bdffb581d89f19f40380" datatype="html">
+        <source>Countries</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="cc1f09ccc4db74d6d42f5dd647f061d86d857c60" datatype="html">
+        <source>Governments</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="d46cab8761b81984adf73aa599930ae8b5a4c1ed" datatype="html">
+        <source>Monitors</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
+      <trans-unit id="8617e06849d42c1b655ebff3a0f213a0b7c5e6f3" datatype="html">
+        <source>Laws</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
+        <note priority="1" from="meaning">Menu item</note>
+      </trans-unit>
       <trans-unit id="1a6f616703d75ae22ef5f11706c3815ca04888c5" datatype="html">
         <source>
         New user
@@ -3110,42 +3324,17 @@
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">10</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
-          <context context-type="linenumber">4</context>
-        </context-group>
         <note priority="1" from="description">Caption for the table which lists the users</note>
       </trans-unit>
-      <trans-unit id="30e10cd5f105624805db7f96287a3b7edd5fff9c" datatype="html">
-        <source>My OTP</source>
-        <target/>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
-          <context context-type="linenumber">1</context>
-        </context-group>
-        <note priority="1" from="description">My OTP menu option</note>
-      </trans-unit>
-      <trans-unit id="4b8c7b2a240e413c2c1eb4a69abf371ac5c5742e" datatype="html">
-        <source>Observations</source>
-        <target/>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
-          <context context-type="linenumber">2</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
-          <context context-type="linenumber">13</context>
-        </context-group>
-        <note priority="1" from="description">Observations menu option</note>
-      </trans-unit>
-      <trans-unit id="faf74edc4404313eeb85945cc1a99cc4ff4a6fd6" datatype="html">
+      <trans-unit id="d8ce6578695232c810274be36568aee8217d9e12" datatype="html">
         <source>Fields</source>
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
           <context context-type="linenumber">3</context>
         </context-group>
-        <note priority="1" from="description">Fields menu option</note>
+        <note priority="1" from="description">Main navigation menu (mobile)</note>
+        <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="099668cc93fe681254739694dc7d662069a8b659" datatype="html">
         <source>Register</source>
@@ -3401,6 +3590,15 @@
         </context-group>
         <note priority="1" from="description">Name of the actions columns (containing the edit and delete button)</note>
         <note priority="1" from="meaning">Table of observations</note>
+      </trans-unit>
+      <trans-unit id="4b8c7b2a240e413c2c1eb4a69abf371ac5c5742e" datatype="html">
+        <source>Observations</source>
+        <target/>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Caption for the table which lists the observations</note>
       </trans-unit>
       <trans-unit id="8d68caf60e263e599e86d21321e1939323492821" datatype="html">
         <source>Login</source>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file source-language="en" datatype="plaintext" original="ng2.template" target-language="fr">
+  <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
       <trans-unit id="4f7091778907548985c8b4a592fa68e0f4c3368e" datatype="html">
         <source>404. Page not found</source>
-        <target state="final">404. Page indisponible</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="7b899c5c53c6d77238cbc42d49e17dcac27ba085" datatype="html">
         <source>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</source>
-        <target state="final">Cette page est introuvable, a été renommée ou est temporairement indisponible.</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -24,17 +24,17 @@
       </trans-unit>
       <trans-unit id="7fb2c801d64dddc6287ab33765a74490ff471cc3" datatype="html">
         <source>Go to my OTP</source>
-        <target state="final">Aller à mon OTP</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">5</context>
         </context-group>
-        <note priority="1" from="description">Button to suggest the user to go to the 'My OTP' page</note>
+        <note priority="1" from="description">Button to suggest the user to go to the &apos;My OTP&apos; page</note>
         <note priority="1" from="meaning">404 page</note>
       </trans-unit>
       <trans-unit id="e32a02d7bc279823ef3a51428092c600cc181612" datatype="html">
         <source>Go to login page</source>
-        <target state="final">Se connecter</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/page-not-found/page-not-found.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="bebaee9b83b435336940bd0f6bbecbefb8b81470" datatype="html">
         <source>Undefined table</source>
-        <target state="new">Undefined table</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -53,7 +53,7 @@
       </trans-unit>
       <trans-unit id="5a97a400bac7feaf727c8bf556aaef97e34d82ea" datatype="html">
         <source>, sorted by</source>
-        <target state="new">, sorted by</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">8</context>
@@ -62,7 +62,7 @@
       </trans-unit>
       <trans-unit id="6e0fa4af5418a615a1a09c67e32682e6b69c0f79" datatype="html">
         <source>ascendent</source>
-        <target state="new">ascendent</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">8</context>
@@ -71,7 +71,7 @@
       </trans-unit>
       <trans-unit id="547d6a7a6de920a2aefc34eeec1b9fc3d393bbb8" datatype="html">
         <source>descendent</source>
-        <target state="new">descendent</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">8</context>
@@ -80,7 +80,7 @@
       </trans-unit>
       <trans-unit id="6219cbb729e72ee75b30c2ce46d7959d1d09aa8d" datatype="html">
         <source>Page</source>
-        <target state="new">Page</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">48</context>
@@ -90,7 +90,7 @@
       </trans-unit>
       <trans-unit id="e3706b34167ca5b613defa8be3a5d4c6316741e5" datatype="html">
         <source>Previous</source>
-        <target state="new">Previous</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">51</context>
@@ -100,7 +100,7 @@
       </trans-unit>
       <trans-unit id="274039dd3b5e706302cf2c3c433ea450bdd49703" datatype="html">
         <source>Next</source>
-        <target state="new">Next</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/table/table.component.ts</context>
           <context context-type="linenumber">61</context>
@@ -110,7 +110,7 @@
       </trans-unit>
       <trans-unit id="65701e62f4eb6566c62a6088842f6f95fa8ef48e" datatype="html">
         <source>Organization profile</source>
-        <target state="new">Organization profile</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -119,12 +119,12 @@
           <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
           <context context-type="linenumber">11</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'My OTP' page</note>
+        <note priority="1" from="description">Menu located on the &apos;My OTP&apos; page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="fb32420414820f45d127a9e6f51985800d930fbb" datatype="html">
         <source>My observations</source>
-        <target state="new">My observations</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -133,12 +133,12 @@
           <context context-type="sourcefile">app/pages/my-otp/my-otp.component.ts</context>
           <context context-type="linenumber">12</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'My OTP' page</note>
+        <note priority="1" from="description">Menu located on the &apos;My OTP&apos; page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="fa9b7116761f013fe509c7646dee9d1e9c3cc31a" datatype="html">
         <source>Name of the organization</source>
-        <target state="new">Name of the organization</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">7</context>
@@ -148,7 +148,7 @@
       </trans-unit>
       <trans-unit id="d5035c69fba58edb578fe982eb8a03175f494319" datatype="html">
         <source>Name is required</source>
-        <target state="new">Name is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -161,12 +161,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">54</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name of the organization isn't supplied</note>
+        <note priority="1" from="description">Error message if the name of the organization isn&apos;t supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="43ecccfbfb54901f26ce0d24939dbfff4315e553" datatype="html">
         <source>Address</source>
-        <target state="new">Address</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -176,17 +176,17 @@
       </trans-unit>
       <trans-unit id="5aa48f8e4b18078364f9fa7af5fd13b8a4ade535" datatype="html">
         <source>Address is required</source>
-        <target state="new">Address is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">15</context>
         </context-group>
-        <note priority="1" from="description">Error message if the address isn't supplied</note>
+        <note priority="1" from="description">Error message if the address isn&apos;t supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="7a19016a7b3167d2713f39b788e5e7d80f3f737d" datatype="html">
         <source>Contact information (General information)</source>
-        <target state="new">Contact information (General information)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">19</context>
@@ -196,7 +196,7 @@
       </trans-unit>
       <trans-unit id="1bb6270fc515c0526e262c35cf24ba9cf34bf917" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">24</context>
@@ -205,12 +205,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">52</context>
         </context-group>
-        <note priority="1" from="description">Label for the contact's name field (general information)</note>
+        <note priority="1" from="description">Label for the contact&apos;s name field (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="caff929db9ef4d149aee1cc57926540ee74b88db" datatype="html">
         <source>Email</source>
-        <target state="new">Email</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">30</context>
@@ -219,12 +219,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">58</context>
         </context-group>
-        <note priority="1" from="description">Label for the contact's email field (general information)</note>
+        <note priority="1" from="description">Label for the contact&apos;s email field (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="d642a03eb15d9e04e7577d51323276179b7324e2" datatype="html">
         <source>Email is required</source>
-        <target state="new">Email is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">32</context>
@@ -233,12 +233,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">60</context>
         </context-group>
-        <note priority="1" from="description">Error message if the contact email isn't supplied (general information)</note>
+        <note priority="1" from="description">Error message if the contact email isn&apos;t supplied (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="f5de8925e983f8662cf13f3f03d94643ba8eee8c" datatype="html">
         <source>Please enter an email address</source>
-        <target state="new">Please enter an email address</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -247,12 +247,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">61</context>
         </context-group>
-        <note priority="1" from="description">Error message if the contact email isn't valid (general information)</note>
+        <note priority="1" from="description">Error message if the contact email isn&apos;t valid (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="ddabada26b82beaa67cb0b3fdcf54a282921afe1" datatype="html">
         <source>Phone number</source>
-        <target state="new">Phone number</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -261,12 +261,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">65</context>
         </context-group>
-        <note priority="1" from="description">Label for the contact's phone number field (general information)</note>
+        <note priority="1" from="description">Label for the contact&apos;s phone number field (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="178268700e3527de634d28f7e397b10a5cecd7a0" datatype="html">
         <source>Phone number is required</source>
-        <target state="new">Phone number is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">39</context>
@@ -275,12 +275,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">67</context>
         </context-group>
-        <note priority="1" from="description">Error message if the contact phone number isn't supplied (general information)</note>
+        <note priority="1" from="description">Error message if the contact phone number isn&apos;t supplied (general information)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="15681d9d8184e095004288f60aace675ddc8e930" datatype="html">
         <source>Contact information (For inquiries on data uploaded)</source>
-        <target state="new">Contact information (For inquiries on data uploaded)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">47</context>
@@ -290,7 +290,7 @@
       </trans-unit>
       <trans-unit id="8056edf01468679e6f762fece7279fd0a31c0474" datatype="html">
         <source>Type of organization</source>
-        <target state="new">Type of organization</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">75</context>
@@ -300,7 +300,7 @@
       </trans-unit>
       <trans-unit id="286a22f1d01b750cc5f9fe1fc0053494c4fb9411" datatype="html">
         <source>Non governmental organization (NGO)</source>
-        <target state="new">Non governmental organization (NGO)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">77</context>
@@ -309,7 +309,7 @@
       </trans-unit>
       <trans-unit id="8ae0be16277ef1c4b8c160c21c709addaafdf4b7" datatype="html">
         <source>Academic</source>
-        <target state="new">Academic</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">78</context>
@@ -318,7 +318,7 @@
       </trans-unit>
       <trans-unit id="6de33973fba79ddbbc39cf39c100d1818d363ab1" datatype="html">
         <source>Research Institute</source>
-        <target state="new">Research Institute</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">79</context>
@@ -327,7 +327,7 @@
       </trans-unit>
       <trans-unit id="9afb9078f854a9c32cdf55d49309ef19b5b6338d" datatype="html">
         <source>Private company</source>
-        <target state="new">Private company</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">80</context>
@@ -336,7 +336,7 @@
       </trans-unit>
       <trans-unit id="c2a9de3714f5767b174d0424bc8abe2dc37acc41" datatype="html">
         <source>Other</source>
-        <target state="new">Other</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">81</context>
@@ -349,17 +349,17 @@
       </trans-unit>
       <trans-unit id="77ddb384bda36384bf19fd82da34668638cd1237" datatype="html">
         <source>Please select a type of organization</source>
-        <target state="new">Please select a type of organization</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">83</context>
         </context-group>
-        <note priority="1" from="description">Error message if the type of organization isn't supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="description">Error message if the type of organization isn&apos;t supplied (the user will have to choose between some options)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="c1351de8b39808e0f027828afbaf48eafbefb36c" datatype="html">
         <source>Please specify:</source>
-        <target state="new">Please specify:</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">87</context>
@@ -373,17 +373,17 @@
       </trans-unit>
       <trans-unit id="2c67985932f0441af58f46be0b153bd30f39c5d9" datatype="html">
         <source>Type of organization is required</source>
-        <target state="new">Type of organization is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">89</context>
         </context-group>
-        <note priority="1" from="description">Error message if the 'more specific' type of organization field isn't supplied</note>
+        <note priority="1" from="description">Error message if the &apos;more specific&apos; type of organization field isn&apos;t supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="820d568fbf0cde2dd31e9f7d95fd4496a201189f" datatype="html">
         <source>Type of monitoring organization</source>
-        <target state="new">Type of monitoring organization</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">93</context>
@@ -393,7 +393,7 @@
       </trans-unit>
       <trans-unit id="b06f369749b6fb40f9373986c261c239898aae3e" datatype="html">
         <source>Mandated</source>
-        <target state="new">Mandated</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">95</context>
@@ -406,7 +406,7 @@
       </trans-unit>
       <trans-unit id="f06a9f71b004266aee89162657ea1c86d1315553" datatype="html">
         <source>Semi mandated</source>
-        <target state="new">Semi mandated</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">96</context>
@@ -419,7 +419,7 @@
       </trans-unit>
       <trans-unit id="b56d7b02a4200f20c0f4889025281c8280e88f09" datatype="html">
         <source>Non-mandated (external)</source>
-        <target state="new">Non-mandated (external)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">97</context>
@@ -428,27 +428,27 @@
       </trans-unit>
       <trans-unit id="683a0fe8c12c2ce250c6dd5194f545ae7748db21" datatype="html">
         <source>Please select a type of monitoring organization</source>
-        <target state="new">Please select a type of monitoring organization</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">100</context>
         </context-group>
-        <note priority="1" from="description">Error message if the type of monitoring organization isn't supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="description">Error message if the type of monitoring organization isn&apos;t supplied (the user will have to choose between some options)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="ea6416e29a89c5c714e69d898daba32eb41b698a" datatype="html">
         <source>Type of monitoring organization is required</source>
-        <target state="new">Type of monitoring organization is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">106</context>
         </context-group>
-        <note priority="1" from="description">Error message if the 'more specific' type of monitoring organization field isn't supplied</note>
+        <note priority="1" from="description">Error message if the &apos;more specific&apos; type of monitoring organization field isn&apos;t supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="3f26932174625c41427110ccc2226e504f5c6fbd" datatype="html">
         <source>Current independent monitoring project</source>
-        <target state="new">Current independent monitoring project</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">110</context>
@@ -458,7 +458,7 @@
       </trans-unit>
       <trans-unit id="bf8439c857331fc455d3d031b6e2c60acf4389a9" datatype="html">
         <source>Project title</source>
-        <target state="new">Project title</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">115</context>
@@ -476,17 +476,17 @@
       </trans-unit>
       <trans-unit id="b2140291449def6677aa53569b3c48d84a56c20b" datatype="html">
         <source>Project title is required</source>
-        <target state="new">Project title is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">117</context>
         </context-group>
-        <note priority="1" from="description">Error message if the project title isn't supplied</note>
+        <note priority="1" from="description">Error message if the project title isn&apos;t supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="8c78e20470679aab2f535754cbe129b99bb2df87" datatype="html">
         <source>Lead organization</source>
-        <target state="new">Lead organization</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">121</context>
@@ -504,17 +504,17 @@
       </trans-unit>
       <trans-unit id="e4f0576d34d9e84843eacd1a69357b464c2778bd" datatype="html">
         <source>Lead organization is required</source>
-        <target state="new">Lead organization is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">123</context>
         </context-group>
-        <note priority="1" from="description">Error message if the lead organization of a project isn't supplied</note>
+        <note priority="1" from="description">Error message if the lead organization of a project isn&apos;t supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="7fdfd037df64f59dcc2e76a327cd2706aa70dd5d" datatype="html">
         <source>Start date</source>
-        <target state="new">Start date</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">127</context>
@@ -532,17 +532,17 @@
       </trans-unit>
       <trans-unit id="3aba988d313ad1e91e0422e04026526c026e4344" datatype="html">
         <source>Start date is required</source>
-        <target state="new">Start date is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">129</context>
         </context-group>
-        <note priority="1" from="description">Error message if the start date of a project isn't supplied</note>
+        <note priority="1" from="description">Error message if the start date of a project isn&apos;t supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="a4cecf67712a605f7eb501374d3265fd12478cec" datatype="html">
         <source>Project duration (years)</source>
-        <target state="new">Project duration (years)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">133</context>
@@ -560,17 +560,17 @@
       </trans-unit>
       <trans-unit id="32acf484fd94a7bbb5192328b88f846d21f96fb3" datatype="html">
         <source>Project duration is required</source>
-        <target state="new">Project duration is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">135</context>
         </context-group>
-        <note priority="1" from="description">Error message if the duration in years of a project isn't supplied</note>
+        <note priority="1" from="description">Error message if the duration in years of a project isn&apos;t supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="8a56af3ab6bb5ee118d69244fac33c11ab40a24b" datatype="html">
         <source>Donor(s)</source>
-        <target state="new">Donor(s)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">139</context>
@@ -588,17 +588,17 @@
       </trans-unit>
       <trans-unit id="d1be0cb8729481903a941dcc95235e5df34d1144" datatype="html">
         <source>Donor(s) is required</source>
-        <target state="new">Donor(s) is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">141</context>
         </context-group>
-        <note priority="1" from="description">Error message if the donor(s) isn't supplied</note>
+        <note priority="1" from="description">Error message if the donor(s) isn&apos;t supplied</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="6fd3fac713c24d0b1eb41ae210a92956dc47e067" datatype="html">
         <source>Project website</source>
-        <target state="new">Project website</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">145</context>
@@ -616,7 +616,7 @@
       </trans-unit>
       <trans-unit id="61db125afe28f6cda94785420bbad6344cd6db25" datatype="html">
         <source>Additional information on status, progress, etc.</source>
-        <target state="new">Additional information on status, progress, etc.</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">150</context>
@@ -634,7 +634,7 @@
       </trans-unit>
       <trans-unit id="49819b177c45f46e71178ef87bc2888c67948703" datatype="html">
         <source>Website link</source>
-        <target state="new">Website link</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">161</context>
@@ -644,17 +644,17 @@
       </trans-unit>
       <trans-unit id="dfc9e62e50d1da01fa8fd0b6b7bcc02a6816d784" datatype="html">
         <source>Organisation’s mission (max 250 characters)</source>
-        <target state="new">Organisation’s mission (max 250 characters)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">166</context>
         </context-group>
-        <note priority="1" from="description">Label for the organization's mission field (with a limit of 250 chars)</note>
+        <note priority="1" from="description">Label for the organization&apos;s mission field (with a limit of 250 chars)</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="e132818042799ae0d6af75d59ecfe7ad2997a9c5" datatype="html">
         <source>You exceed the maximum number of characters</source>
-        <target state="new">You exceed the maximum number of characters</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">168</context>
@@ -663,12 +663,12 @@
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">174</context>
         </context-group>
-        <note priority="1" from="description">Error message if the organization's mission exceeds 250 chars</note>
+        <note priority="1" from="description">Error message if the organization&apos;s mission exceeds 250 chars</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="6bf5e59e896974c50b48e83196c5cf1b334791cb" datatype="html">
         <source>Quality control (max 500 characters)</source>
-        <target state="new">Quality control (max 500 characters)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">172</context>
@@ -678,17 +678,17 @@
       </trans-unit>
       <trans-unit id="9714e9ae169a4c3cd16f982682d05002706c3e75" datatype="html">
         <source>Geographical scope of work</source>
-        <target state="new">Geographical scope of work</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">178</context>
         </context-group>
-        <note priority="1" from="description">Label for the organization's geographical scope field</note>
+        <note priority="1" from="description">Label for the organization&apos;s geographical scope field</note>
         <note priority="1" from="meaning">Organization profile</note>
       </trans-unit>
       <trans-unit id="c7ec8a666155407083e0df211e21f1bddc5b5304" datatype="html">
         <source>Sub-national</source>
-        <target state="new">Sub-national</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">180</context>
@@ -697,7 +697,7 @@
       </trans-unit>
       <trans-unit id="4ebd5411731ecbd28a246b00fbe62d5e76356d36" datatype="html">
         <source>National</source>
-        <target state="new">National</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">181</context>
@@ -706,7 +706,7 @@
       </trans-unit>
       <trans-unit id="cb683c4a7564df4ad793eedad2a5ac342ecf5c12" datatype="html">
         <source>International</source>
-        <target state="new">International</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">182</context>
@@ -715,7 +715,7 @@
       </trans-unit>
       <trans-unit id="d3cbd7eedb32d830d50c4ca6e0f2440b00af4c6c" datatype="html">
         <source>Project 1</source>
-        <target state="new">Project 1</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">194</context>
@@ -725,7 +725,7 @@
       </trans-unit>
       <trans-unit id="c518f75c849d225f2ca6141925c505dd9606ec2e" datatype="html">
         <source>Project 2</source>
-        <target state="new">Project 2</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">239</context>
@@ -735,7 +735,7 @@
       </trans-unit>
       <trans-unit id="6a6369d9cf34dd7374275a93fea20c243877bf99" datatype="html">
         <source>Less details</source>
-        <target state="new">Less details</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">291</context>
@@ -744,7 +744,7 @@
       </trans-unit>
       <trans-unit id="711a50f8cce91ebfb36614abe4e25c400480c269" datatype="html">
         <source>More details</source>
-        <target state="new">More details</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">292</context>
@@ -753,7 +753,7 @@
       </trans-unit>
       <trans-unit id="b4b9d2e75328589d6f50655d26d370b8a8168365" datatype="html">
         <source>Discard changes</source>
-        <target state="new">Discard changes</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">303</context>
@@ -762,7 +762,7 @@
       </trans-unit>
       <trans-unit id="5b3075e8dc3f3921ec316b0bd83b6d14a06c1a4f" datatype="html">
         <source>Save changes</source>
-        <target state="new">Save changes</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/my-otp/profile/organization-profile.component.ts</context>
           <context context-type="linenumber">304</context>
@@ -771,7 +771,7 @@
       </trans-unit>
       <trans-unit id="dafa8a6b3ce5af28ce08ad9b57a82328126b5003" datatype="html">
         <source>Update observation</source>
-        <target state="new">Update observation</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -781,7 +781,7 @@
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
-        <target state="new">Cancel</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -930,7 +930,7 @@
       </trans-unit>
       <trans-unit id="047f50bc5b5d17b5bec0196355953e1a5c590ddb" datatype="html">
         <source>Update</source>
-        <target state="new">Update</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">7</context>
@@ -959,7 +959,7 @@
       </trans-unit>
       <trans-unit id="2ced27c89ab044b68b5fc5f112e9fdb823d78073" datatype="html">
         <source>Type</source>
-        <target state="new">Type</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -973,7 +973,7 @@
       </trans-unit>
       <trans-unit id="c39d43f18d10f925621abc77ad15de80a9cc7516" datatype="html">
         <source>Operator</source>
-        <target state="new">Operator</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -986,7 +986,7 @@
       </trans-unit>
       <trans-unit id="edd600fa489d1b4a4448dce694ed932e52ce8fda" datatype="html">
         <source>Governance</source>
-        <target state="new">Governance</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">17</context>
@@ -999,7 +999,7 @@
       </trans-unit>
       <trans-unit id="8ac4ffef0bab3e3fef5a739f8f0659a27edbf5ab" datatype="html">
         <source>Country</source>
-        <target state="new">Country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">24</context>
@@ -1013,7 +1013,7 @@
       </trans-unit>
       <trans-unit id="66c8bc89c06a678f7956435165f15539fb6fcbf9" datatype="html">
         <source>Please select a country</source>
-        <target state="new">Please select a country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">29</context>
@@ -1022,12 +1022,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">28</context>
         </context-group>
-        <note priority="1" from="description">Error message if the country isn't supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="f81df4984ec9a7a25ca1a255e70c37cf0b3fc768" datatype="html">
         <source>Latitude</source>
-        <target state="new">Latitude</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -1041,7 +1041,7 @@
       </trans-unit>
       <trans-unit id="9103deeab9ec8e9c404a9b613f32c40f8b81435b" datatype="html">
         <source>Latitude is required</source>
-        <target state="new">Latitude is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">36</context>
@@ -1050,12 +1050,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <note priority="1" from="description">Error message if the latitude isn't supplied</note>
+        <note priority="1" from="description">Error message if the latitude isn&apos;t supplied</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="4d643d02cb8a26d011ecbc2cc65e36d6c79285b6" datatype="html">
         <source>Please enter a valid number</source>
-        <target state="new">Please enter a valid number</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -1072,12 +1072,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">42</context>
         </context-group>
-        <note priority="1" from="description">Error message if the latitude isn't valid</note>
+        <note priority="1" from="description">Error message if the latitude isn&apos;t valid</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="bcb1edd093495a7f451ec73bda71a390fd9b7bb0" datatype="html">
         <source>Longitude</source>
-        <target state="new">Longitude</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">41</context>
@@ -1091,7 +1091,7 @@
       </trans-unit>
       <trans-unit id="dfe47cc2c10ef51aec72676718979323da406949" datatype="html">
         <source>Longitude is required</source>
-        <target state="new">Longitude is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">44</context>
@@ -1100,12 +1100,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">41</context>
         </context-group>
-        <note priority="1" from="description">Error message if the longitude isn't supplied</note>
+        <note priority="1" from="description">Error message if the longitude isn&apos;t supplied</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="47147103a9753d3a57d16858149ad097aef3a20c" datatype="html">
         <source>Sub-category</source>
-        <target state="new">Sub-category</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">49</context>
@@ -1127,7 +1127,7 @@
       </trans-unit>
       <trans-unit id="6bedd241a7533daaee02997b78ec87bdd2d2fb5a" datatype="html">
         <source>Please select a sub-category</source>
-        <target state="new">Please select a sub-category</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">54</context>
@@ -1144,12 +1144,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">60</context>
         </context-group>
-        <note priority="1" from="description">Error message if the sub-category isn't supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the sub-category isn&apos;t supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="2836d984c7fd9f88dde6ca18f69d18ae66c268e2" datatype="html">
         <source>Severity</source>
-        <target state="new">Severity</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">67</context>
@@ -1163,7 +1163,7 @@
       </trans-unit>
       <trans-unit id="4f9d0961548c19b80893a1354e2ffd8dad7347f4" datatype="html">
         <source>Please select a severity</source>
-        <target state="new">Please select a severity</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">72</context>
@@ -1172,12 +1172,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">68</context>
         </context-group>
-        <note priority="1" from="description">Error message if the severity isn't supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the severity isn&apos;t supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="1497e5043b0c1da86c5469b69d4c7497ff523438" datatype="html">
         <source>Publication date</source>
-        <target state="new">Publication date</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">76</context>
@@ -1191,7 +1191,7 @@
       </trans-unit>
       <trans-unit id="849521cde58edf20f3e8b3d596c0b4843603b3e8" datatype="html">
         <source>Publication date is required</source>
-        <target state="new">Publication date is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">78</context>
@@ -1200,12 +1200,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">74</context>
         </context-group>
-        <note priority="1" from="description">Error message if the publication date isn't supplied</note>
+        <note priority="1" from="description">Error message if the publication date isn&apos;t supplied</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="59cfebb84dc089e652e54b56dfd1127f5331bd8c" datatype="html">
         <source>Government Entity</source>
-        <target state="new">Government Entity</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">82</context>
@@ -1219,7 +1219,7 @@
       </trans-unit>
       <trans-unit id="f0fd741b7784b50be4e7de22cc464106848b6673" datatype="html">
         <source>Please select a government entity</source>
-        <target state="new">Please select a government entity</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">86</context>
@@ -1228,12 +1228,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">82</context>
         </context-group>
-        <note priority="1" from="description">Error message if the government entity isn't supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the government entity isn&apos;t supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="755a1c920f1be9572a38de2d2b0dda3b701c78f4" datatype="html">
         <source>PV</source>
-        <target state="new">PV</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">90</context>
@@ -1247,7 +1247,7 @@
       </trans-unit>
       <trans-unit id="7ced18ad4df34b20929de05b0ebe6bfa213c5472" datatype="html">
         <source>Opinion of operator</source>
-        <target state="new">Opinion of operator</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">95</context>
@@ -1261,7 +1261,7 @@
       </trans-unit>
       <trans-unit id="f066e1eb28d8ae8a8877b138277b4c05e1c0c226" datatype="html">
         <source>Litigation status</source>
-        <target state="new">Litigation status</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">101</context>
@@ -1275,7 +1275,7 @@
       </trans-unit>
       <trans-unit id="b4a2de6607352730a6af5fcb59263e27439f2c5a" datatype="html">
         <source>Monitor</source>
-        <target state="new">Monitor</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">107</context>
@@ -1289,7 +1289,7 @@
       </trans-unit>
       <trans-unit id="ffeb07b7af4b3905ed99ac72ad636ca63bc05dc8" datatype="html">
         <source>Please select a monitor</source>
-        <target state="new">Please select a monitor</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">111</context>
@@ -1298,12 +1298,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">105</context>
         </context-group>
-        <note priority="1" from="description">Error message if the monitor isn't supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the monitor isn&apos;t supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="dd2f34de17cff8207d4e0ec104bc093faac2b8eb" datatype="html">
         <source>Operator</source>
-        <target state="new">Operator</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">115</context>
@@ -1317,7 +1317,7 @@
       </trans-unit>
       <trans-unit id="c70b9e0c5e8e83b7427e178e4f95ab6559c43224" datatype="html">
         <source>Please select an operator</source>
-        <target state="new">Please select an operator</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">119</context>
@@ -1326,12 +1326,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">113</context>
         </context-group>
-        <note priority="1" from="description">Error message if the operator isn't supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the operator isn&apos;t supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="711d402d0117e5b0abb02c988648b9c41ea13975" datatype="html">
         <source>Active</source>
-        <target state="new">Active</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">123</context>
@@ -1345,7 +1345,7 @@
       </trans-unit>
       <trans-unit id="c324d1ec6ff085cd19e6bce739b05ad9475e0672" datatype="html">
         <source>Details</source>
-        <target state="new">Details</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">128</context>
@@ -1359,7 +1359,7 @@
       </trans-unit>
       <trans-unit id="7e9e4e7c021c606a03a4cd3f5b9331bd37fb109d" datatype="html">
         <source>Evidence</source>
-        <target state="new">Evidence</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail-edit.component.ts</context>
           <context context-type="linenumber">133</context>
@@ -1375,9 +1375,7 @@
         <source>
       New governance sub-category
     </source>
-        <target state="new">
-      New governance sub-category
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -1386,7 +1384,7 @@
       </trans-unit>
       <trans-unit id="f59e607fb08307278ff4d632a8403cc7250f40b7" datatype="html">
         <source>Governance Pillar</source>
-        <target state="new">Governance Pillar</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -1396,7 +1394,7 @@
       </trans-unit>
       <trans-unit id="646cbe17a5d08e57cb34928dfe7fa7cd23481ce0" datatype="html">
         <source>Governance Problem</source>
-        <target state="new">Governance Problem</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -1406,7 +1404,7 @@
       </trans-unit>
       <trans-unit id="f5f4971be2896724f7402e018c02e4998d0f7165" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -1416,7 +1414,7 @@
       </trans-unit>
       <trans-unit id="7d29efb5dea57b061811390c578b3c386ac28802" datatype="html">
         <source>Sub-categories (Governance)</source>
-        <target state="new">Sub-categories (Governance)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -1425,7 +1423,7 @@
       </trans-unit>
       <trans-unit id="9c16ee275da84e3a95d9ee5f7bb01a42ef3df5b2" datatype="html">
         <source>New governance sub-category</source>
-        <target state="new">New governance sub-category</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -1435,7 +1433,7 @@
       </trans-unit>
       <trans-unit id="7891175220c7fe8e6e94d10cf7726ede071792fc" datatype="html">
         <source>Update governance sub-category</source>
-        <target state="new">Update governance sub-category</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -1445,7 +1443,7 @@
       </trans-unit>
       <trans-unit id="70a67e04629f6d412db0a12d51820b480788d795" datatype="html">
         <source>Create</source>
-        <target state="new">Create</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -1582,7 +1580,7 @@
       </trans-unit>
       <trans-unit id="6909f80c54d37a94153b18d639d4dbf990634bf7" datatype="html">
         <source>Governance pillar</source>
-        <target state="new">Governance pillar</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -1592,17 +1590,17 @@
       </trans-unit>
       <trans-unit id="6ed681ff2468c607172396fc02a073dac8b4efaf" datatype="html">
         <source>Governance pillar is required</source>
-        <target state="new">Governance pillar is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the governance pillar isn't supplied</note>
+        <note priority="1" from="description">Error message if the governance pillar isn&apos;t supplied</note>
         <note priority="1" from="meaning">Governance sub-category creation/edition</note>
       </trans-unit>
       <trans-unit id="a7dc4236b38404ed8d4aa4c9fb780ccc040ccd9e" datatype="html">
         <source>Governance problem</source>
-        <target state="new">Governance problem</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">21</context>
@@ -1612,17 +1610,17 @@
       </trans-unit>
       <trans-unit id="54b7e1b3b75e6445b2f2e6784cb3be46286ea10d" datatype="html">
         <source>Governance problem is required</source>
-        <target state="new">Governance problem is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">23</context>
         </context-group>
-        <note priority="1" from="description">Error message if the governance problem isn't supplied</note>
+        <note priority="1" from="description">Error message if the governance problem isn&apos;t supplied</note>
         <note priority="1" from="meaning">Governance sub-category creation/edition</note>
       </trans-unit>
       <trans-unit id="c277d5768b2a4c5b1925b6c0dc7ec58ae1bc1d05" datatype="html">
         <source>Details</source>
-        <target state="new">Details</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/governance/annex-governance-detail.component.ts</context>
           <context context-type="linenumber">26</context>
@@ -1634,9 +1632,7 @@
         <source>
       New operator sub-category
     </source>
-        <target state="new">
-      New operator sub-category
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -1645,7 +1641,7 @@
       </trans-unit>
       <trans-unit id="400ca8ca7107a0d8e8929b04d8fc4c185d183f1b" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -1655,7 +1651,7 @@
       </trans-unit>
       <trans-unit id="31f4b66a2ffe7471f4f39930204bc4f382f5dfd3" datatype="html">
         <source>Details</source>
-        <target state="new">Details</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -1665,7 +1661,7 @@
       </trans-unit>
       <trans-unit id="f63250c4baab4b9281bc0babcc6ff86338771d19" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -1675,7 +1671,7 @@
       </trans-unit>
       <trans-unit id="01913c9d313d04a592d6aa364ad1e8b13717cd42" datatype="html">
         <source>Sub-categories (Operators)</source>
-        <target state="new">Sub-categories (Operators)</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -1684,7 +1680,7 @@
       </trans-unit>
       <trans-unit id="1da555b26e38aea784e23a1092afa8ba60693dbb" datatype="html">
         <source>New operator sub-category</source>
-        <target state="new">New operator sub-category</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -1694,7 +1690,7 @@
       </trans-unit>
       <trans-unit id="773e146f4baed993f7e61607302504f702ebef35" datatype="html">
         <source>Update operator sub-category</source>
-        <target state="new">Update operator sub-category</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -1704,7 +1700,7 @@
       </trans-unit>
       <trans-unit id="8e29884856ab62e66baed2206fe9f251c542932e" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -1714,17 +1710,17 @@
       </trans-unit>
       <trans-unit id="cf8f4120bf44e9a770d8d4ec2cf0f68c2db7f24e" datatype="html">
         <source>Name is required</source>
-        <target state="new">Name is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn't supplied</note>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
         <note priority="1" from="meaning">Operator sub-category creation/edition</note>
       </trans-unit>
       <trans-unit id="e5ed666f8f6a2589cd3c7979b243e5bc6f78d60d" datatype="html">
         <source>Country</source>
-        <target state="new">Country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -1734,7 +1730,7 @@
       </trans-unit>
       <trans-unit id="1ca5483adf9af728d5d0a98cd364a694cc422e63" datatype="html">
         <source>Law references</source>
-        <target state="new">Law references</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">29</context>
@@ -1744,7 +1740,7 @@
       </trans-unit>
       <trans-unit id="0a6091f7c64135d8ec9439019908e8f1e6d28d6b" datatype="html">
         <source>Details</source>
-        <target state="new">Details</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/operators/annex-operator-detail.component.ts</context>
           <context context-type="linenumber">36</context>
@@ -1754,7 +1750,7 @@
       </trans-unit>
       <trans-unit id="ad9508c67f58f44fd3b4d73925e50fa53de76fb7" datatype="html">
         <source>Operators</source>
-        <target state="new">Operators</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/subcategories.component.ts</context>
           <context context-type="linenumber">2</context>
@@ -1771,12 +1767,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">4</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'Sub-categories' list page</note>
+        <note priority="1" from="description">Menu located on the &apos;Sub-categories&apos; list page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="cefad27e0f05695d2e7d84403f5370fa0ac85c5f" datatype="html">
         <source>Governance</source>
-        <target state="new">Governance</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/subcategories/subcategories.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -1785,12 +1781,12 @@
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">5</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'Sub-categories' list page</note>
+        <note priority="1" from="description">Menu located on the &apos;Sub-categories&apos; list page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="85afe36487fab2e70904c3d796f0ea2f7a5a90a9" datatype="html">
         <source>New category</source>
-        <target state="new">New category</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -1800,7 +1796,7 @@
       </trans-unit>
       <trans-unit id="c9315cc027fda44df7772e7fa05aa74402dc017d" datatype="html">
         <source>Update category</source>
-        <target state="new">Update category</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -1810,7 +1806,7 @@
       </trans-unit>
       <trans-unit id="48df2497540119700a2d0e0f26d629c837fd7fc6" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -1820,21 +1816,19 @@
       </trans-unit>
       <trans-unit id="2637b135fb7dc9dab5d9b2cd507716b80cb98240" datatype="html">
         <source>Name is required</source>
-        <target state="new">Name is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn't supplied</note>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
         <note priority="1" from="meaning">Category creation/edition</note>
       </trans-unit>
       <trans-unit id="d3392cb23bca77d1014e89b5e8aefcfb4ccad87b" datatype="html">
         <source>
       New Operator
     </source>
-        <target state="new">
-      New Operator
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -1843,7 +1837,7 @@
       </trans-unit>
       <trans-unit id="801e19d7c8bfcbcc9ede4749d1885f45759b8c8b" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -1857,7 +1851,7 @@
       </trans-unit>
       <trans-unit id="60a3c060cf7bbe40ffbfc35b0b3bb691a789a4e7" datatype="html">
         <source>Type</source>
-        <target state="new">Type</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -1867,7 +1861,7 @@
       </trans-unit>
       <trans-unit id="4f00329eba86dfea8ce882af55cbe475c00c1036" datatype="html">
         <source>Concession</source>
-        <target state="new">Concession</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -1877,7 +1871,7 @@
       </trans-unit>
       <trans-unit id="b029eee35172b814101cf828fb5f9a61e1391c0f" datatype="html">
         <source>Active</source>
-        <target state="new">Active</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -1887,7 +1881,7 @@
       </trans-unit>
       <trans-unit id="39ffe1e95aa519b9645e62af04ed0a3cfa032b42" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -1897,7 +1891,7 @@
       </trans-unit>
       <trans-unit id="9d4ed1f582fafcfd1035ea83e58a5e1fe8d6a1a5" datatype="html">
         <source>Operators</source>
-        <target state="new">Operators</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -1906,7 +1900,7 @@
       </trans-unit>
       <trans-unit id="1dbd4bf0057e786321c83ca35a3c4e2b77f181a9" datatype="html">
         <source>New operator</source>
-        <target state="new">New operator</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -1916,7 +1910,7 @@
       </trans-unit>
       <trans-unit id="f0a8d16cabce095b3508ff9dbeb0459b33249e5d" datatype="html">
         <source>Update operator</source>
-        <target state="new">Update operator</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -1926,7 +1920,7 @@
       </trans-unit>
       <trans-unit id="9fd38b8fcd5e17ff3611d046ce724e16a2000109" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -1936,17 +1930,17 @@
       </trans-unit>
       <trans-unit id="77728cbe1d84a03b45077d0bcdb10f2ccbeb223e" datatype="html">
         <source>Name is required</source>
-        <target state="new">Name is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn't supplied</note>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
         <note priority="1" from="meaning">Operator creation/edition</note>
       </trans-unit>
       <trans-unit id="f152c650bc08e63a3b7a2471c3ef3ab62cf3d52b" datatype="html">
         <source>Operator type</source>
-        <target state="new">Operator type</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -1956,7 +1950,7 @@
       </trans-unit>
       <trans-unit id="2a0e9f550a391aa5b4639d2c85ba060358390726" datatype="html">
         <source>Logging</source>
-        <target state="new">Logging</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">24</context>
@@ -1965,7 +1959,7 @@
       </trans-unit>
       <trans-unit id="6ef0619a37140118b9e640c6cc36ee4e9fb4372a" datatype="html">
         <source>Company</source>
-        <target state="new">Company</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">25</context>
@@ -1978,7 +1972,7 @@
       </trans-unit>
       <trans-unit id="99186438c83c4c7e8b9cc78dfa43f7fd524b5e6e" datatype="html">
         <source>Artisanal</source>
-        <target state="new">Artisanal</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">26</context>
@@ -1987,7 +1981,7 @@
       </trans-unit>
       <trans-unit id="0ad4531bb4bd5e0c7770dfdd89a99befcad6c8ea" datatype="html">
         <source>Sawmill</source>
-        <target state="new">Sawmill</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">27</context>
@@ -1996,7 +1990,7 @@
       </trans-unit>
       <trans-unit id="f5a5b7fe27eecc145ce874a267d55abd47590494" datatype="html">
         <source>Community Forest</source>
-        <target state="new">Community Forest</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">28</context>
@@ -2005,7 +1999,7 @@
       </trans-unit>
       <trans-unit id="e856ab987b69555ee8e5f8cd7e442de3eabea7f4" datatype="html">
         <source>ARB1327</source>
-        <target state="new">ARB1327</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">29</context>
@@ -2014,7 +2008,7 @@
       </trans-unit>
       <trans-unit id="33cf379d245d5fb087711431420fb0ef6ed3e43b" datatype="html">
         <source>Palm Oil</source>
-        <target state="new">Palm Oil</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">30</context>
@@ -2023,7 +2017,7 @@
       </trans-unit>
       <trans-unit id="5d79e032a7657d92b56373c5cc20d0724ef9c73a" datatype="html">
         <source>Trader</source>
-        <target state="new">Trader</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">31</context>
@@ -2032,12 +2026,12 @@
       </trans-unit>
       <trans-unit id="cafbab33e33e79a58b4eefad43938b99d0426314" datatype="html">
         <source>Please select an operator type</source>
-        <target state="new">Please select an operator type</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <note priority="1" from="description">Error message if the operator type isn't supplied (the user will have to choose between several options)</note>
+        <note priority="1" from="description">Error message if the operator type isn&apos;t supplied (the user will have to choose between several options)</note>
         <note priority="1" from="meaning">Operator creation/edition</note>
       </trans-unit>
       <trans-unit id="fe69558920c9d7980d3f3acf5c1ac18191b180d9" datatype="html">
@@ -2047,12 +2041,7 @@
         <x id="START_TAG_OPTION" ctype="x-option"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_OPTION" ctype="x-option"/>
       <x id="CLOSE_TAG_SELECT" ctype="x-select"/>
     </source>
-        <target state="new">
-      <x id="START_TAG_LABEL" ctype="x-label"/>Country<x id="CLOSE_TAG_LABEL" ctype="x-label"/>
-      <x id="START_TAG_SELECT" ctype="x-select"/>
-        <x id="START_TAG_OPTION" ctype="x-option"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_OPTION" ctype="x-option"/>
-      <x id="CLOSE_TAG_SELECT" ctype="x-select"/>
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -2062,7 +2051,7 @@
       </trans-unit>
       <trans-unit id="8c88e1c3c79928abc132f9da3d38a81a8511fa0a" datatype="html">
         <source>Concession</source>
-        <target state="new">Concession</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">45</context>
@@ -2072,7 +2061,7 @@
       </trans-unit>
       <trans-unit id="3934c8285a2371995bd611a986efcbfa9253b8e2" datatype="html">
         <source>Country centroid</source>
-        <target state="new">Country centroid</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">50</context>
@@ -2082,7 +2071,7 @@
       </trans-unit>
       <trans-unit id="1e033c6c092d12800660484eec7a772925639eb6" datatype="html">
         <source>Active</source>
-        <target state="new">Active</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/operators/operator-detail.component.ts</context>
           <context context-type="linenumber">55</context>
@@ -2094,9 +2083,7 @@
         <source>
       New Country
     </source>
-        <target state="new">
-      New Country
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2105,7 +2092,7 @@
       </trans-unit>
       <trans-unit id="de0beb4f2c7b3619f47224ad8a5feedb860dfc0c" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2115,7 +2102,7 @@
       </trans-unit>
       <trans-unit id="b9d28a4b3787fdb725362102e55e54541497723c" datatype="html">
         <source>ISO</source>
-        <target state="new">ISO</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2125,7 +2112,7 @@
       </trans-unit>
       <trans-unit id="902f1ade07cad3f447858b17c2da63e8f7e26ce8" datatype="html">
         <source>Region Name</source>
-        <target state="new">Region Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2135,7 +2122,7 @@
       </trans-unit>
       <trans-unit id="6bb7c94296bdb62165caa3ed3e9151390c0811f9" datatype="html">
         <source>Active</source>
-        <target state="new">Active</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -2145,7 +2132,7 @@
       </trans-unit>
       <trans-unit id="ab07255a444e77bef3e19ddaca4b72a1c8eb360e" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -2155,7 +2142,7 @@
       </trans-unit>
       <trans-unit id="aee7d0de4e30405c1289745e4264e622b613632a" datatype="html">
         <source>Countries</source>
-        <target state="new">Countries</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2164,7 +2151,7 @@
       </trans-unit>
       <trans-unit id="e4a0e02a470737d8053a8ced70e98d1978442484" datatype="html">
         <source>New country</source>
-        <target state="new">New country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -2174,7 +2161,7 @@
       </trans-unit>
       <trans-unit id="c9eed87bc1809a6190cb533f6e034c8c240721ea" datatype="html">
         <source>Update country</source>
-        <target state="new">Update country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2184,7 +2171,7 @@
       </trans-unit>
       <trans-unit id="f9a075ede38c8f0b8e1ebc8a636ff9c2e1d2d5ac" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -2194,17 +2181,17 @@
       </trans-unit>
       <trans-unit id="7772f40a6bf4492246a964933bcd562d63690558" datatype="html">
         <source>Name is required</source>
-        <target state="new">Name is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn't supplied</note>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
         <note priority="1" from="meaning">Country creation/edition</note>
       </trans-unit>
       <trans-unit id="fa04f51e70170a51b8409850619f58194170bf81" datatype="html">
         <source>Region name</source>
-        <target state="new">Region name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -2214,7 +2201,7 @@
       </trans-unit>
       <trans-unit id="5620a84efc9854a3c1c04b51762b8c12ff7ba334" datatype="html">
         <source>ISO</source>
-        <target state="new">ISO</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">27</context>
@@ -2224,17 +2211,17 @@
       </trans-unit>
       <trans-unit id="85c0d8144b112baf450f3265187ed54f3cedb65a" datatype="html">
         <source>ISO is required</source>
-        <target state="new">ISO is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">29</context>
         </context-group>
-        <note priority="1" from="description">Error message if the ISO code isn't supplied</note>
+        <note priority="1" from="description">Error message if the ISO code isn&apos;t supplied</note>
         <note priority="1" from="meaning">Country creation/edition</note>
       </trans-unit>
       <trans-unit id="2808eef1afd0850f3fc4d5bb4af9c8d760a83537" datatype="html">
         <source>Region ISO</source>
-        <target state="new">Region ISO</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -2244,7 +2231,7 @@
       </trans-unit>
       <trans-unit id="f4ba7b2b4ecc25e0b57747d4cc613996662cb0c4" datatype="html">
         <source>Country centroid</source>
-        <target state="new">Country centroid</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">38</context>
@@ -2254,7 +2241,7 @@
       </trans-unit>
       <trans-unit id="6dc87818baaf0762c2e63182ecbf55ef11907b2a" datatype="html">
         <source>Region centroid</source>
-        <target state="new">Region centroid</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">43</context>
@@ -2264,7 +2251,7 @@
       </trans-unit>
       <trans-unit id="8a1e8e453f1ca7b66f462780f073fd214fd7a012" datatype="html">
         <source>Available for observations?</source>
-        <target state="new">Available for observations?</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/countries/country-detail.component.ts</context>
           <context context-type="linenumber">48</context>
@@ -2276,9 +2263,7 @@
         <source>
       New species
     </source>
-        <target state="new">
-      New species
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2287,7 +2272,7 @@
       </trans-unit>
       <trans-unit id="7d1762ee4d496a6c991fde6dcfbec7af4144c1cc" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2297,7 +2282,7 @@
       </trans-unit>
       <trans-unit id="79c4cd49d2cd2f84007b9e115400686f56986a1e" datatype="html">
         <source>Species class</source>
-        <target state="new">Species class</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2307,7 +2292,7 @@
       </trans-unit>
       <trans-unit id="c7703ff5d60e6ef26ff13b44cbb0265e145a1888" datatype="html">
         <source>Scientific name</source>
-        <target state="new">Scientific name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2317,7 +2302,7 @@
       </trans-unit>
       <trans-unit id="6a5cd6a6798a329a413178bdbbbe22c5edd66d89" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -2327,7 +2312,7 @@
       </trans-unit>
       <trans-unit id="ec2b122ed8617f51ed128267a65711e40e56b5bc" datatype="html">
         <source>Species</source>
-        <target state="new">Species</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2338,9 +2323,7 @@
         <source>
       New Monitor
     </source>
-        <target state="new">
-      New Monitor
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2349,7 +2332,7 @@
       </trans-unit>
       <trans-unit id="ebe3ca55e2a451ca15ee5d9b7310f0377b6e2b0e" datatype="html">
         <source>Date</source>
-        <target state="new">Date</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2359,7 +2342,7 @@
       </trans-unit>
       <trans-unit id="c818c652325d319c5fa88875471f20eb663a12b3" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2369,7 +2352,7 @@
       </trans-unit>
       <trans-unit id="b2ef1717958c380c23c8921591715b7fbaf91cb8" datatype="html">
         <source>Type</source>
-        <target state="new">Type</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2379,7 +2362,7 @@
       </trans-unit>
       <trans-unit id="b1d9f070c335abb9c7877c5effde44fc31d7346c" datatype="html">
         <source>Organization</source>
-        <target state="new">Organization</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -2389,7 +2372,7 @@
       </trans-unit>
       <trans-unit id="b4237c13c658454f4a55897e4a3cf73c30a80e0e" datatype="html">
         <source>Active</source>
-        <target state="new">Active</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -2399,7 +2382,7 @@
       </trans-unit>
       <trans-unit id="53e3ce2b1d00ae0c8f1f2d8cabbab9cfd91c67ff" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-list.component.ts</context>
           <context context-type="linenumber">15</context>
@@ -2411,9 +2394,7 @@
         <source>
       New law
     </source>
-        <target state="new">
-      New law
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2422,7 +2403,7 @@
       </trans-unit>
       <trans-unit id="67572ae9cc69d32f40b3259490b91cecc3f5f85d" datatype="html">
         <source>Legal Reference</source>
-        <target state="new">Legal Reference</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2432,7 +2413,7 @@
       </trans-unit>
       <trans-unit id="94380867a6d2b9b39396e6754e7d10d8ebe9085e" datatype="html">
         <source>Legal Penalty</source>
-        <target state="new">Legal Penalty</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2442,7 +2423,7 @@
       </trans-unit>
       <trans-unit id="8070d4dfa7c8357d6d5ce2b1f920d6d584dc9cdc" datatype="html">
         <source>VPA indicator</source>
-        <target state="new">VPA indicator</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -2452,7 +2433,7 @@
       </trans-unit>
       <trans-unit id="0610fd99f9f9b25f432fb2bd65249748420efc70" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -2462,7 +2443,7 @@
       </trans-unit>
       <trans-unit id="d9f85cde7086ccd4c97fc1ae6e656dd68db51d4b" datatype="html">
         <source>Laws</source>
-        <target state="new">Laws</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2471,7 +2452,7 @@
       </trans-unit>
       <trans-unit id="ebc02487572b7b91efac0f364a963de1836fc422" datatype="html">
         <source>New species</source>
-        <target state="new">New species</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2481,7 +2462,7 @@
       </trans-unit>
       <trans-unit id="4e20ed317e78bb9276d249261909b0dd7b89fdbe" datatype="html">
         <source>Update species</source>
-        <target state="new">Update species</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -2491,7 +2472,7 @@
       </trans-unit>
       <trans-unit id="9450101fd324b122e3c2eebe39ea1efb73ed835a" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">17</context>
@@ -2501,17 +2482,17 @@
       </trans-unit>
       <trans-unit id="6e79c544a6f881f3b2bc6c311136b1b07e61db80" datatype="html">
         <source>Name is required</source>
-        <target state="new">Name is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn't supplied</note>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
         <note priority="1" from="meaning">Species creation/edition</note>
       </trans-unit>
       <trans-unit id="6513c8fc3343f39e6523ebcb32977f7fd74a6042" datatype="html">
         <source>Common name</source>
-        <target state="new">Common name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">23</context>
@@ -2521,7 +2502,7 @@
       </trans-unit>
       <trans-unit id="dd0a5f500aef0ecaac829d038616a1c561b644e7" datatype="html">
         <source>Scientific name</source>
-        <target state="new">Scientific name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">28</context>
@@ -2531,7 +2512,7 @@
       </trans-unit>
       <trans-unit id="2cbd3b29e44968bc1915613d5cd3e31b41237adb" datatype="html">
         <source>Species class</source>
-        <target state="new">Species class</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -2541,7 +2522,7 @@
       </trans-unit>
       <trans-unit id="53f592247ce5bd687d87c9e07f6d9eed9d30da20" datatype="html">
         <source>Sub species</source>
-        <target state="new">Sub species</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">38</context>
@@ -2551,7 +2532,7 @@
       </trans-unit>
       <trans-unit id="20b6a2bdb411d5ee55c944816a0632c5f4ce8917" datatype="html">
         <source>Species family</source>
-        <target state="new">Species family</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">43</context>
@@ -2561,7 +2542,7 @@
       </trans-unit>
       <trans-unit id="f2203853494dd5e56d65f8ec663b0a9c5d627b55" datatype="html">
         <source>Kingdom</source>
-        <target state="new">Kingdom</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">48</context>
@@ -2571,7 +2552,7 @@
       </trans-unit>
       <trans-unit id="d1cd8111b4fe023923f890c0a7c44cc94cada286" datatype="html">
         <source>CITES status</source>
-        <target state="new">CITES status</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">53</context>
@@ -2581,7 +2562,7 @@
       </trans-unit>
       <trans-unit id="1f823441a94afdbe8a76e2677645c4dee6bdb3b3" datatype="html">
         <source>IUCN status</source>
-        <target state="new">IUCN status</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/species/species-detail.component.ts</context>
           <context context-type="linenumber">58</context>
@@ -2591,7 +2572,7 @@
       </trans-unit>
       <trans-unit id="f7b77c07f0f64b0f4946d066ccb7caf42f6d64f5" datatype="html">
         <source>New monitor</source>
-        <target state="new">New monitor</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2601,7 +2582,7 @@
       </trans-unit>
       <trans-unit id="d37e644a3c2fe4a97af5fc04c5ba23c50ca0d1bc" datatype="html">
         <source>Update monitor</source>
-        <target state="new">Update monitor</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -2611,7 +2592,7 @@
       </trans-unit>
       <trans-unit id="970d6446f3e343408a02266007c4782e5ffc18e2" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">17</context>
@@ -2621,17 +2602,17 @@
       </trans-unit>
       <trans-unit id="2f23d7732da6de204b25e720af0932539533f290" datatype="html">
         <source>Name is required</source>
-        <target state="new">Name is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn't supplied</note>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
         <note priority="1" from="meaning">Monitor creation/edition</note>
       </trans-unit>
       <trans-unit id="f09fef617d6a9de0ef89d7e9a9582ebe111dd27e" datatype="html">
         <source>Monitor type</source>
-        <target state="new">Monitor type</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">23</context>
@@ -2641,7 +2622,7 @@
       </trans-unit>
       <trans-unit id="72638e600ce222ed8184c47260bbd68d362e693e" datatype="html">
         <source>External</source>
-        <target state="new">External</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">27</context>
@@ -2650,7 +2631,7 @@
       </trans-unit>
       <trans-unit id="59d614de306c59782f5daa000ac64ab78986dfe3" datatype="html">
         <source>Government</source>
-        <target state="new">Government</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">28</context>
@@ -2659,17 +2640,17 @@
       </trans-unit>
       <trans-unit id="f92e4776a0e55bc1f62e42a33492a06fcf1ef6f4" datatype="html">
         <source>Please select a type of monitor</source>
-        <target state="new">Please select a type of monitor</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">30</context>
         </context-group>
-        <note priority="1" from="description">Error message if the monitor type isn't supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="description">Error message if the monitor type isn&apos;t supplied (the user will have to choose between some options)</note>
         <note priority="1" from="meaning">Monitor creation/edition</note>
       </trans-unit>
       <trans-unit id="56e1213f23dc45ca22b840ca175d09878c2fa327" datatype="html">
         <source>Country</source>
-        <target state="new">Country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">34</context>
@@ -2679,17 +2660,17 @@
       </trans-unit>
       <trans-unit id="c474aac05e8433059be3ef9df630c75d919d91f0" datatype="html">
         <source>Organization</source>
-        <target state="new">Organization</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">41</context>
         </context-group>
-        <note priority="1" from="description">Label for the organization's name field</note>
+        <note priority="1" from="description">Label for the organization&apos;s name field</note>
         <note priority="1" from="meaning">Monitor creation/edition</note>
       </trans-unit>
       <trans-unit id="2423329875b86c153e867d7b73ca084967a5ca4d" datatype="html">
         <source>Active</source>
-        <target state="new">Active</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/observers/observer-detail.component.ts</context>
           <context context-type="linenumber">46</context>
@@ -2699,7 +2680,7 @@
       </trans-unit>
       <trans-unit id="902d8c9a37cd5dbfbf804818d51018f57ee5ff6f" datatype="html">
         <source>New law</source>
-        <target state="new">New law</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -2709,7 +2690,7 @@
       </trans-unit>
       <trans-unit id="f936a2051fc16836b5957df80ea4daf45dac6fb4" datatype="html">
         <source>Update law</source>
-        <target state="new">Update law</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2719,7 +2700,7 @@
       </trans-unit>
       <trans-unit id="4ed0d6f64ddd3927b180003fed3cfec68eeca9fc" datatype="html">
         <source>Legal reference</source>
-        <target state="new">Legal reference</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -2729,17 +2710,17 @@
       </trans-unit>
       <trans-unit id="1f5821b1de3e5287dd47d5afd1c73e8481f334a4" datatype="html">
         <source>Legal reference is required</source>
-        <target state="new">Legal reference is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the legal reference isn't supplied</note>
+        <note priority="1" from="description">Error message if the legal reference isn&apos;t supplied</note>
         <note priority="1" from="meaning">Law creation/edition</note>
       </trans-unit>
       <trans-unit id="5dee6b0be929a8b581a7d1e1dadb99163583707d" datatype="html">
         <source>Country</source>
-        <target state="new">Country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -2749,17 +2730,17 @@
       </trans-unit>
       <trans-unit id="5909daed5b4040739fd19794fc9eb601db3840f7" datatype="html">
         <source>Please select a country</source>
-        <target state="new">Please select a country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">26</context>
         </context-group>
-        <note priority="1" from="description">Error message if the country isn't supplied (the user will have to choose between some options)</note>
+        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to choose between some options)</note>
         <note priority="1" from="meaning">Law creation/edition</note>
       </trans-unit>
       <trans-unit id="0ba722b8181589f48f6982c2e6289a3a7e638b30" datatype="html">
         <source>VPA indicator</source>
-        <target state="new">VPA indicator</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">29</context>
@@ -2769,7 +2750,7 @@
       </trans-unit>
       <trans-unit id="da81d170cec9c56d085e1a83d72a75083fb34bde" datatype="html">
         <source>Legal penalty</source>
-        <target state="new">Legal penalty</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/laws/law-detail.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -2779,7 +2760,7 @@
       </trans-unit>
       <trans-unit id="da0e191e3b5ce9a03ebf6935c7a3da8f1df39963" datatype="html">
         <source>New government</source>
-        <target state="new">New government</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -2789,7 +2770,7 @@
       </trans-unit>
       <trans-unit id="d63b452dfa4a1be6a31c188edf56b946a9bc3a36" datatype="html">
         <source>Update government</source>
-        <target state="new">Update government</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -2799,7 +2780,7 @@
       </trans-unit>
       <trans-unit id="994f851a27e09e9b2eb725f832cc0d6406362b63" datatype="html">
         <source>Government entity</source>
-        <target state="new">Government entity</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -2809,17 +2790,17 @@
       </trans-unit>
       <trans-unit id="d3a14f1a9f2eccb2b150c1a53d36ff3642f41664" datatype="html">
         <source>Government entity is required</source>
-        <target state="new">Government entity is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the government entity isn't supplied</note>
+        <note priority="1" from="description">Error message if the government entity isn&apos;t supplied</note>
         <note priority="1" from="meaning">Government creation/edition</note>
       </trans-unit>
       <trans-unit id="0b577ea470cf9239b9ee5a7f49e1648b38450413" datatype="html">
         <source>Country</source>
-        <target state="new">Country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -2829,17 +2810,17 @@
       </trans-unit>
       <trans-unit id="f2fae309178d62c60d650f78ee2f5076fc48cb02" datatype="html">
         <source>Please select a country</source>
-        <target state="new">Please select a country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">26</context>
         </context-group>
-        <note priority="1" from="description">Error message if the country isn't supplied (the user will have to choose between serveral options)</note>
+        <note priority="1" from="description">Error message if the country isn&apos;t supplied (the user will have to choose between serveral options)</note>
         <note priority="1" from="meaning">Government creation/edition</note>
       </trans-unit>
       <trans-unit id="070870f728185c5169acfbd58382939274fcbc27" datatype="html">
         <source>Details</source>
-        <target state="new">Details</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-detail.component.ts</context>
           <context context-type="linenumber">30</context>
@@ -2851,9 +2832,7 @@
         <source>
       New government unit
     </source>
-        <target state="new">
-      New government unit
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2862,7 +2841,7 @@
       </trans-unit>
       <trans-unit id="7375730a696290da1ac4a1b41aa1807227704d38" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2872,7 +2851,7 @@
       </trans-unit>
       <trans-unit id="a77615221336090843bf4217630174cf0aaadcb2" datatype="html">
         <source>Details</source>
-        <target state="new">Details</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2882,7 +2861,7 @@
       </trans-unit>
       <trans-unit id="77d0d5ee531ac0867be1b0ce429d9f23314fa4cd" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2892,7 +2871,7 @@
       </trans-unit>
       <trans-unit id="648fe89999cc59abebc2ff5e62c7f4f619bf456e" datatype="html">
         <source>Governments</source>
-        <target state="new">Governments</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/governments/government-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2903,9 +2882,7 @@
         <source>
       New Category
     </source>
-        <target state="new">
-      New Category
-    </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2914,7 +2891,7 @@
       </trans-unit>
       <trans-unit id="3e44dbcc81d17832a393250e494929e0b6382c0b" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -2924,7 +2901,7 @@
       </trans-unit>
       <trans-unit id="a0d9d59763903ebae40d4d8e3b62ffbf5d3d717a" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2934,7 +2911,7 @@
       </trans-unit>
       <trans-unit id="04201f9d27abd7d6f58a4328ab98063ce1072006" datatype="html">
         <source>Categories</source>
-        <target state="new">Categories</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/categories/category-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -2943,7 +2920,7 @@
       </trans-unit>
       <trans-unit id="daf4f4c015509bb67eb6d6d726b256a8615d7758" datatype="html">
         <source>Open Timber Portal</source>
-        <target state="new">Open Timber Portal</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -2952,7 +2929,7 @@
       </trans-unit>
       <trans-unit id="3fdc751b264ca9998e1542fcf5794e274cd56344" datatype="html">
         <source>Log out</source>
-        <target state="new">Log out</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -2961,7 +2938,7 @@
       </trans-unit>
       <trans-unit id="791b002647a2f49818c508b2860c68e7f23b17b6" datatype="html">
         <source>My OTP</source>
-        <target state="final">Mon OTP</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -2975,7 +2952,7 @@
       </trans-unit>
       <trans-unit id="831b9ec431d2a93a412ef510bd1fae36c721400a" datatype="html">
         <source>Observations</source>
-        <target state="final">Observations</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -2989,7 +2966,7 @@
       </trans-unit>
       <trans-unit id="dbe0f319ddd1cc5c17d1a4e9585996c89fd2d05c" datatype="html">
         <source>Observation fields</source>
-        <target state="final">Domaines d'observation</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -2999,7 +2976,7 @@
       </trans-unit>
       <trans-unit id="74b0fac259eeefc9f20aeb6a1bd08931012390c9" datatype="html">
         <source>Users</source>
-        <target state="final">Utilisateurs</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/header/header.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -3013,7 +2990,7 @@
       </trans-unit>
       <trans-unit id="1ae1df848c628a7a059c1ff57be3449ecacc5c91" datatype="html">
         <source>New user</source>
-        <target state="new">New user</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -3023,7 +3000,7 @@
       </trans-unit>
       <trans-unit id="7663160100ebcc9a117c8cb206b0624e172f89c9" datatype="html">
         <source>Update user</source>
-        <target state="new">Update user</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -3033,7 +3010,7 @@
       </trans-unit>
       <trans-unit id="4b43d07d0171b690cd5d541d649389af16378912" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">21</context>
@@ -3043,17 +3020,17 @@
       </trans-unit>
       <trans-unit id="a8077802820f0bac578cee128f3146719d87c292" datatype="html">
         <source>Name is required</source>
-        <target state="new">Name is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">23</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn't supplied</note>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="9531f868dd03aac6f0d2687eed93dd57d4fcb910" datatype="html">
         <source>Username</source>
-        <target state="new">Username</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">27</context>
@@ -3063,17 +3040,17 @@
       </trans-unit>
       <trans-unit id="517d85ca7650f90dd91f14a4e3ecffab28967926" datatype="html">
         <source>Username is required</source>
-        <target state="new">Username is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">29</context>
         </context-group>
-        <note priority="1" from="description">Error message if the username/nickname isn't supplied</note>
+        <note priority="1" from="description">Error message if the username/nickname isn&apos;t supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="62dc5076c0fe3427ba6a0ed17008cecea393c1a1" datatype="html">
         <source>Email</source>
-        <target state="new">Email</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -3083,27 +3060,27 @@
       </trans-unit>
       <trans-unit id="6c46fe594e7a68965a97b78ef5e22859e5781d68" datatype="html">
         <source>Email is required</source>
-        <target state="new">Email is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">35</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn't supplied</note>
+        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="ad967d9088a765aebf92c3116b8f5398d6e2de09" datatype="html">
         <source>Please enter an email address</source>
-        <target state="new">Please enter an email address</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">36</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn't valid</note>
+        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="9515b8c96b948fff69c74667be3248115e876ed2" datatype="html">
         <source>Institution</source>
-        <target state="new">Institution</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">40</context>
@@ -3113,7 +3090,7 @@
       </trans-unit>
       <trans-unit id="e9959215c7e71edde620b01439f5ffbecd5d2b27" datatype="html">
         <source>Country</source>
-        <target state="new">Country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">45</context>
@@ -3123,7 +3100,7 @@
       </trans-unit>
       <trans-unit id="4fe21c99a9c7a18ae378c3e0958b146f21e56ad9" datatype="html">
         <source>Password</source>
-        <target state="new">Password</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">53</context>
@@ -3133,17 +3110,17 @@
       </trans-unit>
       <trans-unit id="795dfb8a206622b513661b3ecdb0e697e4cd1e0f" datatype="html">
         <source>Password is required</source>
-        <target state="new">Password is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">55</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password isn't supplied</note>
+        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="0decdfdf829ae2fdedebac57ce24f1cbdca085fb" datatype="html">
         <source>Confirm your password</source>
-        <target state="new">Confirm your password</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">59</context>
@@ -3153,27 +3130,27 @@
       </trans-unit>
       <trans-unit id="8c0add49e7d050ab76f5f1bf53b43410f95d73bb" datatype="html">
         <source>Please confirm your password</source>
-        <target state="new">Please confirm your password</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">61</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password confirmation isn't supplied</note>
+        <note priority="1" from="description">Error message if the password confirmation isn&apos;t supplied</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="03a6fc721e7fcdae64bb5982a0674ca3c45d1870" datatype="html">
-        <source>Password values don't not coincide</source>
-        <target state="new">Password values don't not coincide</target>
+        <source>Password values don&apos;t not coincide</source>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">62</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password and its confirmation don't coincide'</note>
+        <note priority="1" from="description">Error message if the password and its confirmation don&apos;t coincide&apos;</note>
         <note priority="1" from="meaning">User creation/edition</note>
       </trans-unit>
       <trans-unit id="d0003e833df402846f87694894de69a744609fcb" datatype="html">
         <source>Permissions</source>
-        <target state="new">Permissions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">67</context>
@@ -3183,7 +3160,7 @@
       </trans-unit>
       <trans-unit id="408cb6073e60c5d966296a3207fc596adca75e01" datatype="html">
         <source>Admin</source>
-        <target state="new">Admin</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">69</context>
@@ -3192,7 +3169,7 @@
       </trans-unit>
       <trans-unit id="e652540fcb10505228ef38a3a9790a94a3728fc5" datatype="html">
         <source>NGO</source>
-        <target state="new">NGO</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-detail.component.ts</context>
           <context context-type="linenumber">70</context>
@@ -3201,7 +3178,7 @@
       </trans-unit>
       <trans-unit id="f3dba5732cb548f04fc8b4727e3568f5169956f1" datatype="html">
         <source>New observation</source>
-        <target state="new">New observation</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -3211,17 +3188,17 @@
       </trans-unit>
       <trans-unit id="a01fcf88689d79ed060dce1f72b5adeaa7b46faf" datatype="html">
         <source>Please select a observation type</source>
-        <target state="new">Please select a observation type</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-detail.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Error message if the type isn't supplied (the user will have to user between some options)</note>
+        <note priority="1" from="description">Error message if the type isn&apos;t supplied (the user will have to user between some options)</note>
         <note priority="1" from="meaning">Observation creation/edition</note>
       </trans-unit>
       <trans-unit id="5c50b2cbccccfacca324cac86084eea6dca8a9b6" datatype="html">
         <source>Categories</source>
-        <target state="new">Categories</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -3230,12 +3207,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">16</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="c5c1ede612299da54bd1911c2afff91164c6d67d" datatype="html">
         <source>Sub-categories</source>
-        <target state="new">Sub-categories</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -3244,12 +3221,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="c61f95bc9d62cf3b27e0de4d2ccafdec84025876" datatype="html">
         <source>Species</source>
-        <target state="new">Species</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">5</context>
@@ -3258,12 +3235,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="cbaa4c8a4a07ae77d139bdffb581d89f19f40380" datatype="html">
         <source>Countries</source>
-        <target state="new">Countries</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -3272,12 +3249,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="cc1f09ccc4db74d6d42f5dd647f061d86d857c60" datatype="html">
         <source>Governments</source>
-        <target state="new">Governments</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">7</context>
@@ -3286,12 +3263,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">20</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="d46cab8761b81984adf73aa599930ae8b5a4c1ed" datatype="html">
         <source>Monitors</source>
-        <target state="new">Monitors</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -3300,12 +3277,12 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">22</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="8617e06849d42c1b655ebff3a0f213a0b7c5e6f3" datatype="html">
         <source>Laws</source>
-        <target state="new">Laws</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -3314,16 +3291,14 @@
           <context context-type="sourcefile">app/pages/fields/field-list.component.ts</context>
           <context context-type="linenumber">23</context>
         </context-group>
-        <note priority="1" from="description">Menu located on the 'Observations fields' page</note>
+        <note priority="1" from="description">Menu located on the &apos;Observations fields&apos; page</note>
         <note priority="1" from="meaning">Menu item</note>
       </trans-unit>
       <trans-unit id="1a6f616703d75ae22ef5f11706c3815ca04888c5" datatype="html">
         <source>
         New user
       </source>
-        <target state="new">
-        New user
-      </target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">4</context>
@@ -3332,7 +3307,7 @@
       </trans-unit>
       <trans-unit id="408d18faf367209fe427e59b979f2b44901e0e7c" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -3342,7 +3317,7 @@
       </trans-unit>
       <trans-unit id="0a15a5d859d810d87d241e8c1e0320a6bf4eaab6" datatype="html">
         <source>Username</source>
-        <target state="new">Username</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -3352,7 +3327,7 @@
       </trans-unit>
       <trans-unit id="d9a3cb1133a129319296a62a6592ccb4633c37ad" datatype="html">
         <source>Email</source>
-        <target state="new">Email</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -3362,7 +3337,7 @@
       </trans-unit>
       <trans-unit id="7ed96443291c57e0eef0a6f1adcbf1a3013449a4" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -3372,7 +3347,7 @@
       </trans-unit>
       <trans-unit id="4d13a9cd5ed3dcee0eab22cb25198d43886942be" datatype="html">
         <source>Users</source>
-        <target state="new">Users</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/users/user-list.component.ts</context>
           <context context-type="linenumber">10</context>
@@ -3381,7 +3356,7 @@
       </trans-unit>
       <trans-unit id="d8ce6578695232c810274be36568aee8217d9e12" datatype="html">
         <source>Fields</source>
-        <target state="final">Domaines</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/shared/bottom-bar/bottom-bar.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -3391,7 +3366,7 @@
       </trans-unit>
       <trans-unit id="099668cc93fe681254739694dc7d662069a8b659" datatype="html">
         <source>Register</source>
-        <target state="new">Register</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">2</context>
@@ -3401,7 +3376,7 @@
       </trans-unit>
       <trans-unit id="245198374604dd2866e843ca1411b3b5bee26b4b" datatype="html">
         <source>Name</source>
-        <target state="new">Name</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -3411,17 +3386,17 @@
       </trans-unit>
       <trans-unit id="455490d6079d0287a4dd8a51d0087c7df48e018c" datatype="html">
         <source>Name is required</source>
-        <target state="new">Name is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">8</context>
         </context-group>
-        <note priority="1" from="description">Error message if the name isn't supplied</note>
+        <note priority="1" from="description">Error message if the name isn&apos;t supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="077471e569722451975586da916fe91f1eede0f0" datatype="html">
         <source>Username</source>
-        <target state="new">Username</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">11</context>
@@ -3431,17 +3406,17 @@
       </trans-unit>
       <trans-unit id="89434c6c32783ce50a9818d919b0cfcf1883dfe7" datatype="html">
         <source>Username is required</source>
-        <target state="new">Username is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">13</context>
         </context-group>
-        <note priority="1" from="description">Error message if the username/nickname isn't supplied</note>
+        <note priority="1" from="description">Error message if the username/nickname isn&apos;t supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="67e26ffa056d34f8f5c34cfe01af731f4667d420" datatype="html">
         <source>Institution</source>
-        <target state="new">Institution</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">16</context>
@@ -3451,7 +3426,7 @@
       </trans-unit>
       <trans-unit id="ff8c80b065ad5802b5d2539e41ec7bfa14c65646" datatype="html">
         <source>Country</source>
-        <target state="new">Country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">20</context>
@@ -3461,7 +3436,7 @@
       </trans-unit>
       <trans-unit id="0e420cff0712db35b0fb636b9c7b73182307ee48" datatype="html">
         <source>Email</source>
-        <target state="new">Email</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">26</context>
@@ -3471,27 +3446,27 @@
       </trans-unit>
       <trans-unit id="e3e6b8f98dd44b6c1cb5834713b771004b15369a" datatype="html">
         <source>Email is required</source>
-        <target state="new">Email is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">28</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn't supplied</note>
+        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="0852bccb9acdfc7c24ea9f89f997812e20c5f66c" datatype="html">
         <source>Please enter an email address</source>
-        <target state="new">Please enter an email address</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">29</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn't valid</note>
+        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="8878633ec07d9bfe29eaf51cf501e87fe3df588f" datatype="html">
         <source>Password</source>
-        <target state="new">Password</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">32</context>
@@ -3501,17 +3476,17 @@
       </trans-unit>
       <trans-unit id="37259b13dc58cf4ece14d58b0e3c3dc883105168" datatype="html">
         <source>Password is required</source>
-        <target state="new">Password is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password isn't supplied</note>
+        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="87d9a4f470c63e0b8bfe7279223532e87adf6f08" datatype="html">
         <source>Confirm your password</source>
-        <target state="new">Confirm your password</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -3521,27 +3496,27 @@
       </trans-unit>
       <trans-unit id="a6f6372f4dd465f68c31293774b454b477bdc918" datatype="html">
         <source>Please confirm your password</source>
-        <target state="new">Please confirm your password</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">39</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password confirmation isn't supplied</note>
+        <note priority="1" from="description">Error message if the password confirmation isn&apos;t supplied</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="c45bce7d5bebd3886fa2ec661b234da55c062f54" datatype="html">
-        <source>Password values don't not coincide</source>
-        <target state="new">Password values don't not coincide</target>
+        <source>Password values don&apos;t not coincide</source>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">40</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password and it's confirmation don't coincide</note>
+        <note priority="1" from="description">Error message if the password and it&apos;s confirmation don&apos;t coincide</note>
         <note priority="1" from="meaning">Register page</note>
       </trans-unit>
       <trans-unit id="6765b4c916060f6bc42d9bb69e80377dbcb5e4e9" datatype="html">
         <source>Login</source>
-        <target state="new">Login</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">43</context>
@@ -3554,7 +3529,7 @@
       </trans-unit>
       <trans-unit id="cfc2f436ec2beffb042e7511a73c89c372e86a6c" datatype="html">
         <source>Register</source>
-        <target state="new">Register</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/register/register.component.ts</context>
           <context context-type="linenumber">44</context>
@@ -3567,7 +3542,7 @@
       </trans-unit>
       <trans-unit id="229210ea5aded39aacf9e7d79e1658b32ca104f6" datatype="html">
         <source>New observation</source>
-        <target state="new">New observation</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -3576,7 +3551,7 @@
       </trans-unit>
       <trans-unit id="00c200adab3e41e35d1e06d42d847d17f747e71c" datatype="html">
         <source>Date</source>
-        <target state="new">Date</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">14</context>
@@ -3586,7 +3561,7 @@
       </trans-unit>
       <trans-unit id="645872c938ac5195a4906afa0f6118cc9b52771b" datatype="html">
         <source>Country</source>
-        <target state="new">Country</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">17</context>
@@ -3596,7 +3571,7 @@
       </trans-unit>
       <trans-unit id="0ea6d0e3424fa1ffdb64a3b98a9815c98b595435" datatype="html">
         <source>Operator</source>
-        <target state="new">Operator</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">18</context>
@@ -3606,7 +3581,7 @@
       </trans-unit>
       <trans-unit id="be0139f1cf8e5feab4a5b691287c7c0d9c74fc86" datatype="html">
         <source>Category</source>
-        <target state="new">Category</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">19</context>
@@ -3616,7 +3591,7 @@
       </trans-unit>
       <trans-unit id="788391ad82018522ef4162b47fb8e81f00217bd6" datatype="html">
         <source>Observation</source>
-        <target state="new">Observation</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">20</context>
@@ -3626,7 +3601,7 @@
       </trans-unit>
       <trans-unit id="a8a36702a876525737fdbabb99b6f5bceac167a6" datatype="html">
         <source>Severity</source>
-        <target state="new">Severity</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">21</context>
@@ -3636,7 +3611,7 @@
       </trans-unit>
       <trans-unit id="f988c370ec8c750c0b84a0c412e440d53cee631d" datatype="html">
         <source>Actions</source>
-        <target state="new">Actions</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">22</context>
@@ -3646,7 +3621,7 @@
       </trans-unit>
       <trans-unit id="4b8c7b2a240e413c2c1eb4a69abf371ac5c5742e" datatype="html">
         <source>Observations</source>
-        <target state="new">Observations</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/observations/observation-list.component.ts</context>
           <context context-type="linenumber">13</context>
@@ -3655,7 +3630,7 @@
       </trans-unit>
       <trans-unit id="8d68caf60e263e599e86d21321e1939323492821" datatype="html">
         <source>Login</source>
-        <target state="new">Login</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">3</context>
@@ -3665,7 +3640,7 @@
       </trans-unit>
       <trans-unit id="4d8a562e319cebae08fb094877d11d80be7ed87d" datatype="html">
         <source>Email</source>
-        <target state="new">Email</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">6</context>
@@ -3675,27 +3650,27 @@
       </trans-unit>
       <trans-unit id="4c7f617fdaf91a9d45c52aa985e99304538bf140" datatype="html">
         <source>Email is required</source>
-        <target state="new">Email is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">8</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn't supplied</note>
+        <note priority="1" from="description">Error message if the email isn&apos;t supplied</note>
         <note priority="1" from="meaning">Login page</note>
       </trans-unit>
       <trans-unit id="dec04191c54f62c23d2012fafcb24c07c198ba58" datatype="html">
         <source>Please enter an email address</source>
-        <target state="new">Please enter an email address</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">9</context>
         </context-group>
-        <note priority="1" from="description">Error message if the email isn't valid</note>
+        <note priority="1" from="description">Error message if the email isn&apos;t valid</note>
         <note priority="1" from="meaning">Login page</note>
       </trans-unit>
       <trans-unit id="69a2b7b2e465e58e7df02173034ee5f9c332ad70" datatype="html">
         <source>Password</source>
-        <target state="new">Password</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">12</context>
@@ -3705,12 +3680,12 @@
       </trans-unit>
       <trans-unit id="ee6940c10dba8bb8734ddb805ccc75c02f0ace8b" datatype="html">
         <source>Password is required</source>
-        <target state="new">Password is required</target>
+        <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">app/pages/login/login.component.ts</context>
           <context context-type="linenumber">14</context>
         </context-group>
-        <note priority="1" from="description">Error message if the password isn't supplied</note>
+        <note priority="1" from="description">Error message if the password isn&apos;t supplied</note>
         <note priority="1" from="meaning">Login page</note>
       </trans-unit>
     </body>

--- a/src/styles/components/form.scss
+++ b/src/styles/components/form.scss
@@ -1,4 +1,4 @@
-@import 'src/settings';
+@import 'src/settings.scss';
 
 .c-form {
   .form-container {

--- a/xliffmerge.json
+++ b/xliffmerge.json
@@ -1,0 +1,6 @@
+{
+  "xliffmergeOptions": {
+    "srcDir": "src/locale",
+    "genDir": "src/locale"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,6 +146,10 @@
   version "2.53.42"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-2.53.42.tgz#74cb77fb6052edaff2a8984ddafd88d419f25cac"
 
+"@types/xmldom@^0.1.29":
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/@types/xmldom/-/xmldom-0.1.29.tgz#c4428b0ca86d3b881475726fd94980b38a27c381"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -3173,6 +3177,22 @@ ng2-slimscroll@^1.2.6:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/ng2-slimscroll/-/ng2-slimscroll-1.3.2.tgz#8b052ca8748080ecce8138f1ab5826beaddf5d49"
 
+ngx-i18nsupport-lib@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ngx-i18nsupport-lib/-/ngx-i18nsupport-lib-1.3.0.tgz#a154d53a709b310b6adcd61e19086902faeec98c"
+  dependencies:
+    "@types/xmldom" "^0.1.29"
+    tokenizr "^1.1.4"
+    xmldom "^0.1.27"
+
+ngx-i18nsupport@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/ngx-i18nsupport/-/ngx-i18nsupport-0.6.1.tgz#54c4203939108b50505dcedd04faaeccbcda604c"
+  dependencies:
+    chalk "^1.1.3"
+    commander "^2.9.0"
+    ngx-i18nsupport-lib "^1.3.0"
+
 no-case@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.1.tgz#7aeba1c73a52184265554b7dc03baf720df80081"
@@ -4862,6 +4882,10 @@ to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
+tokenizr@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/tokenizr/-/tokenizr-1.1.4.tgz#8b9089f14cb490e24ad3872cff1e38e713e884ef"
+
 toposort@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.3.tgz#f02cd8a74bd8be2fc0e98611c3bacb95a171869c"
@@ -5409,7 +5433,7 @@ xmlbuilder@>=1.0.0, xmlbuilder@^4.1.0:
   dependencies:
     lodash "^4.0.0"
 
-xmldom@^0.1.19:
+xmldom@^0.1.19, xmldom@^0.1.27:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 


### PR DESCRIPTION
This PR updates the build process and the interface so the user can toggle the app's language between English and French.

## How the translations are handled

The templates have been all updated so whenever a tag contains some content, it has a `i18n` attribute with some description to let the translators do their job.

⚠️ Every time some new content is added or removed, we need to run a command to regenerate the translation files.

🚫 We must avoid having content strings in the Typescript files as they can't be translated. Only the content of the templates can.

<br/>

The command to regenerate the translations files is: `yarn run extract-i18n` or `npm run extract-i18n`. This command will override the file `src/locale/messages.xlf` with the list of strings to translate and then generate two other files: `messages.en.xlf` and `messages.fr.xlf`. These two files are actually the ones containing the translations.

⚠️ Before manually modifying the two translations files, please read until the end.

🚫 Do not modify `messages.xlf` manually because it can be overrode at any time.

<br/>

The translation files are then handled to the client. Their format is `xlf` which is an industry standard. As an example of free app to open them, this [web app](https://martinroob.github.io/tiny-translator/en/#/) can let the client translate the files online.
The files can also be manually translated by opening them in a text editor. They use an XML syntax and the only tags to modify are the `target` ones. Once a string as been translated, the `state` attribute of the `target` tag must be updated to `final` otherwise the translation could be lost at any time.

⚠️ Make sure the translated strings have the `state` attribute set to `final`.

<br/>

Once the client gives us back the files, we can simply replace the old ones with these new copies.

<br/>

In order to have the translations available online,  we need to rebuild the app with `yarn run prod-build` and then deploy. One bundle per language will be generated but the server should be prepared to handle them.

<br/>

If other languages need to be added in the future, here is a non-exhaustive list of the changes to make:
- In `package.json`, update the two scripts `prod-build` and `extract-i18n` to add the two-letter country code.
- Update the `select`'s options in `header.component.html`.
- Update the server's nginx configuration (see with @rrequero or @davidsingal).
- Rebuild the translation files, build the bundles and deploy.

At this point, the new languages won't have any translations so all the strings will fallback to English.

## Serving the bundles and handling the locale

When a user visits the app, the server searches for a query parameter named `lang`. If it isn't present or is set to a non-supported language, then the English bundle is served. If the locale is supported, then the corresponding bundle is served.

In both cases, the bundles are saved from `/` (i.e. not from a directory) because we want the manifest file and upcoming service worker to be served from the root directory. Even though each bundle has its own manifest and service worker, their code is exactly the same so the browser won't realise they're different.

🚫 Do not make any locale-based difference in these static (and global) files.

<br/>

When the app is loaded in the browser, it automatically adds the `lang` param in the URL, according to the bundle that has been loaded, if not present. This way, if the user shares the URL to someone else, the app will be opened using the same language.

<br/>

To change the language of the app, the user can use the selector located in the header. In order to load the correct translations, the `lang` param is updated to the correct locale and the app reloaded. There is no way to change the language without doing so because internally we serve a different bundle. The URL param is updated before reloading the app because we need to let the server know which bundle to serve.

<br/>

The queries made to the API contains the locale of the bundle in order to serve the translated entities if possible. If not, the fallback is English.